### PR TITLE
Fix Constructor bug in zkEVM Contracts

### DIFF
--- a/contracts/royalty-enforcement/RoyaltyEnforced.sol
+++ b/contracts/royalty-enforcement/RoyaltyEnforced.sol
@@ -56,6 +56,10 @@ abstract contract RoyaltyEnforced is
     function setRoyaltyAllowlistRegistry(
         address _royaltyAllowlist
     ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        _setRoyaltyAllowlistRegistry(_royaltyAllowlist);
+    }
+
+    function _setRoyaltyAllowlistRegistry(address _royaltyAllowlist) internal {
         if (
             !IERC165(_royaltyAllowlist).supportsInterface(
                 type(IRoyaltyAllowlist).interfaceId

--- a/contracts/token/erc721/preset/ImmutableERC721PermissionedMintable.sol
+++ b/contracts/token/erc721/preset/ImmutableERC721PermissionedMintable.sol
@@ -40,7 +40,7 @@ contract ImmutableERC721PermissionedMintable is ImmutableERC721Base {
         // Initialize state variables
         _setDefaultRoyalty(_receiver, _feeNumerator);
         _grantRole(DEFAULT_ADMIN_ROLE, owner);
-        setRoyaltyAllowlistRegistry(_royaltyAllowlist);
+        _setRoyaltyAllowlistRegistry(_royaltyAllowlist);
         baseURI = baseURI_;
         contractURI = contractURI_;
     }


### PR DESCRIPTION
This fixes a big which does not allow the deployer and the owner of the ERC721 preset to be different. 