### PR TITLE
[DX-2440] Add Asset contract deployment script for NFT minting guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 ETHERSCAN_API_KEY=<YOUR_ETHERSCAN_API_KEY>
-ROPSTEN_URL=https://eth-ropsten.alchemyapi.io/v2/<YOUR ALCHEMY KEY>
+SEPOLIA_URL=https://eth-sepolia.g.alchemy.com/v2/<YOUR_ALCHEMY_API_KEY>
+MAINNET_URL=https://eth-mainnet.g.alchemy.com/v2/<YOUR_ALCHEMY_API_KEY>
 PRIVATE_KEY=<YOUR_PRIVATE_KEY>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Immutable zkEVM Contracts
+# Contributing to Immutable Contracts
 
 We greatly appreciate all community feedback and contributions to this repository. This guide will walk you through the different ways you can contribute, including opening GitHub issues, pull requests, requesting features, and providing general feedback. For any security disclosures, please email security@immutable.com.
 

--- a/deploy/utils.ts
+++ b/deploy/utils.ts
@@ -1,0 +1,13 @@
+export const getImmutableBridgeAddress = (network: string) => {
+  switch (network) {
+    case "sepolia":
+      return "0x2d5C349fD8464DA06a3f90b4B0E9195F3d1b7F98"; // sepolia
+    case "mainnet":
+      return "0x5FDCCA53617f4d2b9134B29090C87D01058e27e9";
+  }
+  throw Error("Invalid network selected");
+};
+
+export const sleep = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};

--- a/deploy/x/README.md
+++ b/deploy/x/README.md
@@ -1,0 +1,35 @@
+# Asset Contract Deployment
+
+How to deploy the Asset contract to allow minting on Immutable X.
+
+1. Install project dependencies:
+
+    ```shell
+    yarn install
+    ```
+
+2. Make a copy of `.env.examples` and rename the copy to `.env`:
+
+    ```shell
+    cp .env.example .env
+    ```
+
+3. Update the environment variables in `.env`. You will need the following:
+
+    - [An Etherscan API key](https://docs.etherscan.io/getting-started/viewing-api-usage-statistics).
+    - [Alchemy API keys for Sepolia and Mainnet](https://docs.alchemy.com/docs/alchemy-quickstart-guide#1key-create-an-alchemy-key).
+    - Private key for a wallet with enough ETH to deploy the contract.
+
+4. Generate contract artifacts
+
+    ```shell
+    yarn compile
+    ```
+
+5. Deploy the Asset contract
+
+    ```shell
+    yarn hardhat deploy:x:asset --network sepolia --name "<contract_name>" --symbol <symbol>
+    ```
+
+The deploy task will deploy the contract to the specified network, wait 5 mins to allow time for the contract to deploy, then verify the contract.

--- a/deploy/x/asset.ts
+++ b/deploy/x/asset.ts
@@ -1,0 +1,35 @@
+import { task } from "hardhat/config";
+import { getImmutableBridgeAddress, sleep } from "../utils";
+
+// Deploy Immutable X Asset contract
+// this is used in the Zero-to-Hero guide
+// https://docs.immutable.com/docs/x/zero-to-hero-nft-minting/
+const deployAsset = task("deploy:x:asset", "Deploy the Asset contract")
+  .addParam("name", "Contract name")
+  .addParam("symbol", "Contract symbol")
+  .setAction(async (taskArgs, hre) => {
+    const [deployer] = await hre.ethers.getSigners();
+
+    const owner = deployer.address;
+    const { name, symbol } = taskArgs;
+    const allowedNetworks = ["mainnet", "sepolia"];
+
+    if (!allowedNetworks.includes(hre.network.name)) {
+      throw new Error(`please pass a valid --network [ ${allowedNetworks.join(" | ")} ]`);
+    }
+
+    const Asset = await hre.ethers.getContractFactory("Asset");
+    const immutableBridgeAddress = getImmutableBridgeAddress(hre.network.name);
+    const asset = await Asset.deploy(owner, name, symbol, immutableBridgeAddress);
+
+    console.log("Deployed Contract Address:", asset.address);
+    console.log("Verifying contract in 5 minutes...");
+    await sleep(60000 * 5);
+
+    await hre.run("verify:verify", {
+      address: asset.address,
+      constructorArguments: [owner, name, symbol, immutableBridgeAddress],
+    });
+  });
+
+export default deployAsset;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,11 +1,13 @@
 import * as dotenv from "dotenv";
 
 import { HardhatUserConfig, task } from "hardhat/config";
+import "@nomiclabs/hardhat-ethers";
 import "@nomiclabs/hardhat-etherscan";
 import "@nomiclabs/hardhat-waffle";
 import "@typechain/hardhat";
 import "hardhat-gas-reporter";
 import "solidity-coverage";
+import "./deploy/x/asset";
 
 dotenv.config();
 
@@ -21,7 +23,6 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
 
 // You need to export an object to set up your config
 // Go to https://hardhat.org/config/ to learn more
-
 const config: HardhatUserConfig = {
   solidity: {
     version: "0.8.17",
@@ -36,8 +37,12 @@ const config: HardhatUserConfig = {
     tests: "./test",
   },
   networks: {
-    ropsten: {
-      url: process.env.ROPSTEN_URL || "",
+    sepolia: {
+      url: process.env.SEPOLIA_URL || "",
+      accounts: process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
+    },
+    mainnet: {
+      url: process.env.MAINNET_URL || "",
       accounts: process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
     },
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["./scripts", "./typechain", "./clients", "./test", "./index.ts"],
+  "include": ["./scripts", "./typechain", "./clients", "./test", "./index.ts", "./deploy"],
   "files": ["./hardhat.config.ts"]
 }


### PR DESCRIPTION
Why?

[DX-2440](https://immutable.atlassian.net/browse/DX-2440)

The Asset contract was recently moved into the repo from `imx-contracts` (now deprecated). `imx-contracts` had scripts to deploy the contract which was used in the [NFT minting tutorial](https://docs.immutable.com/docs/x/zero-to-hero-nft-minting/) on the docs website.

The PR adds those deployment scripts to the monorepo so users can continue to use the NFT minting guide with the monorep.

[DX-2440]: https://immutable.atlassian.net/browse/DX-2440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ