### PR TITLE
[GMS-1172] Add metadata fields to ERC1155 preset contract

### DIFF
--- a/contracts/token/erc1155/abstract/ImmutableERC1155Base.sol
+++ b/contracts/token/erc1155/abstract/ImmutableERC1155Base.sol
@@ -1,7 +1,8 @@
 //SPDX-License-Identifier: Apache 2.0
 pragma solidity 0.8.19;
 
-import "contracts/token/erc1155/abstract/ERC1155Permit.Sol";
+import "../../../token/erc1155/abstract/ERC1155Permit.Sol";
+
 // Allowlist
 import "@openzeppelin/contracts/token/common/ERC2981.sol";
 import "../../../allowlist/OperatorAllowlistEnforced.sol";
@@ -14,6 +15,8 @@ abstract contract ImmutableERC1155Base is
     ERC1155Permit,
     ERC2981
 {
+    /// @dev Contract level metadata
+    string public contractURI;
 
     // Optional mapping for token URIs
     mapping(uint256 => string) private _tokenURIs;
@@ -36,6 +39,7 @@ abstract contract ImmutableERC1155Base is
         address owner,
         string memory name_,
         string memory baseURI_,
+        string memory contractURI_,
         address _operatorAllowlist,
         address _receiver,
         uint96 _feeNumerator
@@ -44,6 +48,7 @@ abstract contract ImmutableERC1155Base is
         _grantRole(DEFAULT_ADMIN_ROLE, owner);
         _setDefaultRoyalty(_receiver, _feeNumerator);
         _setOperatorAllowlistRegistry(_operatorAllowlist);
+        contractURI = contractURI_;
     }
 
     /**
@@ -133,6 +138,11 @@ abstract contract ImmutableERC1155Base is
      */
     function setBaseURI(string memory baseURI_) public onlyRole(DEFAULT_ADMIN_ROLE) {
        _setURI(baseURI_);
+    }
+
+    /// @dev Allows admin to set the contract URI
+    function setContractURI(string memory _contractURI) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        contractURI = _contractURI;
     }
 
     /**

--- a/contracts/token/erc1155/abstract/ImmutableERC1155Base.sol
+++ b/contracts/token/erc1155/abstract/ImmutableERC1155Base.sol
@@ -18,6 +18,9 @@ abstract contract ImmutableERC1155Base is
     /// @dev Contract level metadata
     string public contractURI;
 
+    /// @dev Common URIs for individual token URIs
+    string public baseURI;
+
     // Optional mapping for token URIs
     mapping(uint256 => string) private _tokenURIs;
 
@@ -49,6 +52,7 @@ abstract contract ImmutableERC1155Base is
         _setDefaultRoyalty(_receiver, _feeNumerator);
         _setOperatorAllowlistRegistry(_operatorAllowlist);
         contractURI = contractURI_;
+        baseURI = baseURI_;
     }
 
     /**
@@ -138,11 +142,12 @@ abstract contract ImmutableERC1155Base is
      */
     function setBaseURI(string memory baseURI_) public onlyRole(DEFAULT_ADMIN_ROLE) {
        _setURI(baseURI_);
+       baseURI = baseURI_;
     }
 
     /// @dev Allows admin to set the contract URI
-    function setContractURI(string memory _contractURI) public onlyRole(DEFAULT_ADMIN_ROLE) {
-        contractURI = _contractURI;
+    function setContractURI(string memory contractURI_) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        contractURI = contractURI_;
     }
 
     /**

--- a/contracts/token/erc1155/preset/draft-ImmutableERC1155.sol
+++ b/contracts/token/erc1155/preset/draft-ImmutableERC1155.sol
@@ -25,11 +25,12 @@ contract ImmutableERC1155 is ImmutableERC1155Base {
         address owner,
         string memory name_,
         string memory baseURI_,
+        string memory contractURI_,
         address _operatorAllowlist,
         address _receiver,
         uint96 _feeNumerator
     )
-        ImmutableERC1155Base(owner, name_, baseURI_, _operatorAllowlist, _receiver, _feeNumerator)
+        ImmutableERC1155Base(owner, name_, baseURI_, contractURI_, _operatorAllowlist, _receiver, _feeNumerator)
     {}
 
     ///     =====   External functions  =====

--- a/test/token/erc1155/ImmutableERC1155.t.sol
+++ b/test/token/erc1155/ImmutableERC1155.t.sol
@@ -94,7 +94,7 @@ contract ImmutableERC1155Test is Test {
     function test_RevertIfNonAdminAttemptsToSetBaseURI() public {
         vm.prank(vm.addr(anotherPrivateKey));
         vm.expectRevert("AccessControl: account 0x1eff47bc3a10a45d4b230b5d10e37751fe6aa718 is missing role 0x0000000000000000000000000000000000000000000000000000000000000000");
-        immutableERC1155.setBaseURI("new-contract-uri");
+        immutableERC1155.setBaseURI("new-base-uri");
     }
 
     /*

--- a/test/token/erc1155/ImmutableERC1155.t.sol
+++ b/test/token/erc1155/ImmutableERC1155.t.sol
@@ -66,9 +66,9 @@ contract ImmutableERC1155Test is Test {
         assertEq(immutableERC1155.contractURI(), "test-contract-uri");
     }
 
-    // function test_DeploymentShouldSetBaseURI() public {
-    //     assertEq(immutableERC1155.baseURI(), "test-base-uri");
-    // }
+    function test_DeploymentShouldSetBaseURI() public {
+        assertEq(immutableERC1155.baseURI(), "test-base-uri");
+    }
 
     /*
     * Metadata
@@ -85,16 +85,17 @@ contract ImmutableERC1155Test is Test {
         immutableERC1155.setContractURI("new-contract-uri");
     }
 
-    // function test_AdminRoleCanSetBaseURI() public {
-    //     bytes32 adminRole = immutableERC1155.DEFAULT_ADMIN_ROLE();
-    //     immutableERC1155.setBaseURI("new-base-uri");
+    function test_AdminRoleCanSetBaseURI() public {
+        vm.prank(owner);
+        immutableERC1155.setBaseURI("new-base-uri");
+        assertEq(immutableERC1155.baseURI(), "new-base-uri");
+    }
 
-    //     assertTrue(immutableERC1155.hasRole(adminRole, owner));
-    // }
-
-    // function test_RevertIfNonAdminAttemptsToSetBaseURI() public {
-    //     assertEq(immutableERC1155.baseURI(), "test-contract-uri");
-    // }
+    function test_RevertIfNonAdminAttemptsToSetBaseURI() public {
+        vm.prank(vm.addr(anotherPrivateKey));
+        vm.expectRevert("AccessControl: account 0x1eff47bc3a10a45d4b230b5d10e37751fe6aa718 is missing role 0x0000000000000000000000000000000000000000000000000000000000000000");
+        immutableERC1155.setBaseURI("new-contract-uri");
+    }
 
     /*
     * Permits

--- a/test/token/erc1155/ImmutableERC1155.t.sol
+++ b/test/token/erc1155/ImmutableERC1155.t.sol
@@ -30,8 +30,8 @@ contract ImmutableERC1155Test is Test {
         immutableERC1155 = new ImmutableERC1155(
             owner,
             "test",
-            "test",
-            "test",
+            "test-base-uri",
+            "test-contract-uri",
             address(operatorAllowlist),
             feeReceiver,
             0
@@ -55,11 +55,49 @@ contract ImmutableERC1155Test is Test {
     }
 
     /*
-    Contract metadata
+    * Contract deployment
     */
+    function test_DeploymentShouldSetAdminRoleToOwner() public {
+        bytes32 adminRole = immutableERC1155.DEFAULT_ADMIN_ROLE();
+        assertTrue(immutableERC1155.hasRole(adminRole, owner));
+    }
+
+    function test_DeploymentShouldSetContractURI() public {
+        assertEq(immutableERC1155.contractURI(), "test-contract-uri");
+    }
+
+    // function test_DeploymentShouldSetBaseURI() public {
+    //     assertEq(immutableERC1155.baseURI(), "test-base-uri");
+    // }
 
     /*
-    Permits
+    * Metadata
+    */
+    function test_AdminRoleCanSetContractURI() public {
+        vm.prank(owner);
+        immutableERC1155.setContractURI("new-contract-uri");
+        assertEq(immutableERC1155.contractURI(), "new-contract-uri");
+    }
+
+    function test_RevertIfNonAdminAttemptsToSetContractURI() public {
+        vm.prank(vm.addr(anotherPrivateKey));
+        vm.expectRevert("AccessControl: account 0x1eff47bc3a10a45d4b230b5d10e37751fe6aa718 is missing role 0x0000000000000000000000000000000000000000000000000000000000000000");
+        immutableERC1155.setContractURI("new-contract-uri");
+    }
+
+    // function test_AdminRoleCanSetBaseURI() public {
+    //     bytes32 adminRole = immutableERC1155.DEFAULT_ADMIN_ROLE();
+    //     immutableERC1155.setBaseURI("new-base-uri");
+
+    //     assertTrue(immutableERC1155.hasRole(adminRole, owner));
+    // }
+
+    // function test_RevertIfNonAdminAttemptsToSetBaseURI() public {
+    //     assertEq(immutableERC1155.baseURI(), "test-contract-uri");
+    // }
+
+    /*
+    * Permits
     */
     function test_PermitSuccess() public {
         bytes memory sig = _sign(ownerPrivateKey, owner, spender, true, 0, 1 days);

--- a/test/token/erc1155/ImmutableERC1155Test.t.sol
+++ b/test/token/erc1155/ImmutableERC1155Test.t.sol
@@ -31,6 +31,7 @@ contract ImmutableERC1155Test is Test {
             owner,
             "test",
             "test",
+            "test",
             address(operatorAllowlist),
             feeReceiver,
             0
@@ -53,6 +54,13 @@ contract ImmutableERC1155Test is Test {
         sig = abi.encodePacked(r, s, v);
     }
 
+    /*
+    Contract metadata
+    */
+
+    /*
+    Permits
+    */
     function test_PermitSuccess() public {
         bytes memory sig = _sign(ownerPrivateKey, owner, spender, true, 0, 1 days);
 


### PR DESCRIPTION
Adds fields `baseURI` and `contractURI` in order to be compatible with Immutable metadata standards that are consistent with ERC721.

ERC1155 standard contains a `uri` method which acts similar to a baseURI but with ID substitution, for now we are syncing both the `uri` and `baseURI` to be compatible with both approaches.