### PR TITLE
GMS-1207: improves how params are accepts

### DIFF
--- a/clients/erc20.ts
+++ b/clients/erc20.ts
@@ -51,7 +51,7 @@ export class ERC20Client {
   public async populateTransfer(
     to: PromiseOrValue<string>,
     amount: PromiseOrValue<BigNumberish>,
-    overrides?: Overrides & { from?: PromiseOrValue<string> }
+    overrides: Overrides & { from?: PromiseOrValue<string> } = {}
   ): Promise<PopulatedTransaction> {
     return this.contract.populateTransaction.transfer(to, amount, overrides);
   }

--- a/clients/erc721-mint-by-id.ts
+++ b/clients/erc721-mint-by-id.ts
@@ -167,7 +167,7 @@ export class ERC721MintByIDClient {
   public async nonces(
     provider: Provider,
     tokenId: PromiseOrValue<BigNumberish>,
-    overrides?: CallOverrides
+    overrides: CallOverrides = {}
   ): Promise<BigNumber> {
     return await this.contract.connect(provider).nonces(tokenId, overrides);
   }


### PR DESCRIPTION
Uses empty objects as default in order to avoid `undefined` being passed to the main function