### PR TITLE
[NO-JIRA] Fix client gas config

### DIFF
--- a/clients/config/overrides.ts
+++ b/clients/config/overrides.ts
@@ -4,4 +4,5 @@ import { CallOverrides } from "@ethersproject/contracts";
 export const defaultGasOverrides: CallOverrides = {
   maxPriorityFeePerGas: 10e9, // 10 Gwei
   maxFeePerGas: 15e9,
+  gasLimit: 200000, // Expected when setting the above properties
 };

--- a/clients/erc20.ts
+++ b/clients/erc20.ts
@@ -20,7 +20,7 @@ export class ERC20Client {
    * @returns a promise that resolves with a BigNumber that represents the amount of tokens in existence
    */
   public async totalSupply(provider: Provider, overrides: CallOverrides = {}): Promise<BigNumber> {
-    return this.contract.connect(provider).totalSupply({ ...defaultGasOverrides, ...overrides });
+    return this.contract.connect(provider).totalSupply(overrides);
   }
 
   /**
@@ -31,7 +31,7 @@ export class ERC20Client {
     account: PromiseOrValue<string>,
     overrides: CallOverrides = {}
   ): Promise<BigNumber> {
-    return this.contract.connect(provider).balanceOf(account, { ...defaultGasOverrides, ...overrides });
+    return this.contract.connect(provider).balanceOf(account, overrides);
   }
 
   /**
@@ -43,7 +43,7 @@ export class ERC20Client {
     spender: PromiseOrValue<string>,
     overrides: CallOverrides = {}
   ): Promise<BigNumber> {
-    return this.contract.connect(provider).allowance(owner, spender, { ...defaultGasOverrides, ...overrides });
+    return this.contract.connect(provider).allowance(owner, spender, overrides);
   }
 
   /**

--- a/clients/erc721-mint-by-id.ts
+++ b/clients/erc721-mint-by-id.ts
@@ -31,14 +31,14 @@ export class ERC721MintByIDClient {
    * @returns the DEFAULT_ADMIN_ROLE as a string.
    */
   public async DEFAULT_ADMIN_ROLE(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).DEFAULT_ADMIN_ROLE({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).DEFAULT_ADMIN_ROLE(overrides);
   }
 
   /**
    * @returns the MINTER_ROLE as a string.
    */
   public async MINTER_ROLE(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).MINTER_ROLE({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).MINTER_ROLE(overrides);
   }
 
   /**
@@ -49,28 +49,28 @@ export class ERC721MintByIDClient {
     owner: PromiseOrValue<string>,
     overrides: CallOverrides = {}
   ): Promise<BigNumber> {
-    return await this.contract.connect(provider).balanceOf(owner, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).balanceOf(owner, overrides);
   }
 
   /**
    * @returns the baseURI as a string.
    */
   public async baseURI(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).baseURI({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).baseURI(overrides);
   }
 
   /**
    * @returns the contractURI as a string.
    */
   public async contractURI(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).contractURI({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).contractURI(overrides);
   }
 
   /**
    * @returns admin addresses as an array of strings.
    */
   public async getAdmins(provider: Provider, overrides: CallOverrides = {}): Promise<string[]> {
-    return await this.contract.connect(provider).getAdmins({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).getAdmins(overrides);
   }
 
   /**
@@ -81,7 +81,7 @@ export class ERC721MintByIDClient {
     tokenId: PromiseOrValue<BigNumberish>,
     overrides: CallOverrides = {}
   ): Promise<string> {
-    return await this.contract.connect(provider).getApproved(tokenId, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).getApproved(tokenId, overrides);
   }
 
   /**
@@ -92,7 +92,7 @@ export class ERC721MintByIDClient {
     role: PromiseOrValue<BytesLike>,
     overrides: CallOverrides = {}
   ): Promise<string> {
-    return await this.contract.connect(provider).getRoleAdmin(role, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).getRoleAdmin(role, overrides);
   }
 
   /**
@@ -104,7 +104,7 @@ export class ERC721MintByIDClient {
     index: PromiseOrValue<BigNumberish>,
     overrides: CallOverrides = {}
   ): Promise<string> {
-    return await this.contract.connect(provider).getRoleMember(role, index, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).getRoleMember(role, index, overrides);
   }
 
   /**
@@ -115,7 +115,7 @@ export class ERC721MintByIDClient {
     role: PromiseOrValue<BytesLike>,
     overrides: CallOverrides = {}
   ): Promise<BigNumber> {
-    return await this.contract.connect(provider).getRoleMemberCount(role, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).getRoleMemberCount(role, overrides);
   }
 
   /**
@@ -127,7 +127,7 @@ export class ERC721MintByIDClient {
     account: PromiseOrValue<string>,
     overrides: CallOverrides = {}
   ): Promise<boolean> {
-    return await this.contract.connect(provider).hasRole(role, account, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).hasRole(role, account, overrides);
   }
 
   /**
@@ -139,16 +139,14 @@ export class ERC721MintByIDClient {
     operator: PromiseOrValue<string>,
     overrides: CallOverrides = {}
   ): Promise<boolean> {
-    return await this.contract
-      .connect(provider)
-      .isApprovedForAll(owner, operator, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).isApprovedForAll(owner, operator, overrides);
   }
 
   /**
    * @returns the name of the contract as a string.
    */
   public async name(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).name({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).name(overrides);
   }
 
   /**
@@ -159,7 +157,7 @@ export class ERC721MintByIDClient {
     tokenId: PromiseOrValue<BigNumberish>,
     overrides: CallOverrides = {}
   ): Promise<string> {
-    return await this.contract.connect(provider).ownerOf(tokenId, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).ownerOf(tokenId, overrides);
   }
 
   /**
@@ -172,14 +170,14 @@ export class ERC721MintByIDClient {
     tokenId: PromiseOrValue<BigNumberish>,
     overrides: CallOverrides = {}
   ): Promise<BigNumber> {
-    return await this.contract.connect(provider).nonces(tokenId, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).nonces(tokenId, overrides);
   }
 
   /**
    * @returns the operator allowlist as a string.
    */
   public async operatorAllowlist(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).operatorAllowlist({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).operatorAllowlist(overrides);
   }
 
   /**
@@ -191,16 +189,14 @@ export class ERC721MintByIDClient {
     _salePrice: PromiseOrValue<BigNumberish>,
     overrides: CallOverrides = {}
   ): Promise<[string, BigNumber]> {
-    return await this.contract
-      .connect(provider)
-      .royaltyInfo(_tokenId, _salePrice, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).royaltyInfo(_tokenId, _salePrice, overrides);
   }
 
   /**
    * @returns the symbol of the contract as a string.
    */
   public async symbol(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).symbol({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).symbol(overrides);
   }
 
   /**
@@ -211,14 +207,14 @@ export class ERC721MintByIDClient {
     tokenId: PromiseOrValue<BigNumberish>,
     overrides: CallOverrides = {}
   ): Promise<string> {
-    return await this.contract.connect(provider).tokenURI(tokenId, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).tokenURI(tokenId, overrides);
   }
 
   /**
    * @returns returns the total amount of tokens stored by the contract.
    */
   public async totalSupply(provider: Provider, overrides: CallOverrides = {}): Promise<BigNumber> {
-    return await this.contract.connect(provider).totalSupply({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).totalSupply(overrides);
   }
 
   /**

--- a/clients/erc721.ts
+++ b/clients/erc721.ts
@@ -34,7 +34,7 @@ export class ERC721Client {
    * @returns the DEFAULT_ADMIN_ROLE as a string.
    */
   public async DEFAULT_ADMIN_ROLE(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).DEFAULT_ADMIN_ROLE({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).DEFAULT_ADMIN_ROLE(overrides);
   }
 
   /**
@@ -42,14 +42,14 @@ export class ERC721Client {
    * @return the bytes32 domain separator
    */
   public async DOMAIN_SEPARATOR(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).DOMAIN_SEPARATOR({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).DOMAIN_SEPARATOR(overrides);
   }
 
   /**
    * @returns the MINTER_ROLE as a string.
    */
   public async MINTER_ROLE(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).MINTER_ROLE({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).MINTER_ROLE(overrides);
   }
 
   /**
@@ -60,21 +60,21 @@ export class ERC721Client {
     owner: PromiseOrValue<string>,
     overrides: CallOverrides = {}
   ): Promise<BigNumber> {
-    return await this.contract.connect(provider).balanceOf(owner, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).balanceOf(owner, overrides);
   }
 
   /**
    * @returns the baseURI as a string.
    */
   public async baseURI(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).baseURI({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).baseURI(overrides);
   }
 
   /**
    * @returns the contractURI as a string.
    */
   public async contractURI(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).contractURI({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).contractURI(overrides);
   }
 
   /**
@@ -95,14 +95,14 @@ export class ERC721Client {
       extensions: BigNumber[];
     }
   > {
-    return await this.contract.connect(provider).eip712Domain({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).eip712Domain(overrides);
   }
 
   /**
    * @returns admin addresses as an array of strings.
    */
   public async getAdmins(provider: Provider, overrides: CallOverrides = {}): Promise<string[]> {
-    return await this.contract.connect(provider).getAdmins({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).getAdmins(overrides);
   }
 
   /**
@@ -113,7 +113,7 @@ export class ERC721Client {
     tokenId: PromiseOrValue<BigNumberish>,
     overrides: CallOverrides = {}
   ): Promise<string> {
-    return await this.contract.connect(provider).getApproved(tokenId, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).getApproved(tokenId, overrides);
   }
 
   /**
@@ -124,7 +124,7 @@ export class ERC721Client {
     role: PromiseOrValue<BytesLike>,
     overrides: CallOverrides = {}
   ): Promise<string> {
-    return await this.contract.connect(provider).getRoleAdmin(role, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).getRoleAdmin(role, overrides);
   }
 
   /**
@@ -136,7 +136,7 @@ export class ERC721Client {
     index: PromiseOrValue<BigNumberish>,
     overrides: CallOverrides = {}
   ): Promise<string> {
-    return await this.contract.connect(provider).getRoleMember(role, index, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).getRoleMember(role, index, overrides);
   }
 
   /**
@@ -147,7 +147,7 @@ export class ERC721Client {
     role: PromiseOrValue<BytesLike>,
     overrides: CallOverrides = {}
   ): Promise<BigNumber> {
-    return await this.contract.connect(provider).getRoleMemberCount(role, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).getRoleMemberCount(role, overrides);
   }
 
   /**
@@ -159,7 +159,7 @@ export class ERC721Client {
     account: PromiseOrValue<string>,
     overrides: CallOverrides = {}
   ): Promise<boolean> {
-    return await this.contract.connect(provider).hasRole(role, account, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).hasRole(role, account, overrides);
   }
 
   /**
@@ -171,16 +171,14 @@ export class ERC721Client {
     operator: PromiseOrValue<string>,
     overrides: CallOverrides = {}
   ): Promise<boolean> {
-    return await this.contract
-      .connect(provider)
-      .isApprovedForAll(owner, operator, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).isApprovedForAll(owner, operator, overrides);
   }
 
   /**
    * @returns the name of the contract as a string.
    */
   public async name(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).name({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).name(overrides);
   }
 
   /**
@@ -191,7 +189,7 @@ export class ERC721Client {
     tokenId: PromiseOrValue<BigNumberish>,
     overrides: CallOverrides = {}
   ): Promise<string> {
-    return await this.contract.connect(provider).ownerOf(tokenId, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).ownerOf(tokenId, overrides);
   }
 
   /**
@@ -204,14 +202,14 @@ export class ERC721Client {
     tokenId: PromiseOrValue<BigNumberish>,
     overrides: CallOverrides = {}
   ): Promise<BigNumber> {
-    return await this.contract.connect(provider).nonces(tokenId, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).nonces(tokenId, overrides);
   }
 
   /**
    * @returns the operator allowlist as a string.
    */
   public async operatorAllowlist(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).operatorAllowlist({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).operatorAllowlist(overrides);
   }
 
   /**
@@ -223,16 +221,14 @@ export class ERC721Client {
     _salePrice: PromiseOrValue<BigNumberish>,
     overrides: CallOverrides = {}
   ): Promise<[string, BigNumber]> {
-    return await this.contract
-      .connect(provider)
-      .royaltyInfo(_tokenId, _salePrice, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).royaltyInfo(_tokenId, _salePrice, overrides);
   }
 
   /**
    * @returns the symbol of the contract as a string.
    */
   public async symbol(provider: Provider, overrides: CallOverrides = {}): Promise<string> {
-    return await this.contract.connect(provider).symbol({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).symbol(overrides);
   }
 
   /**
@@ -243,14 +239,14 @@ export class ERC721Client {
     tokenId: PromiseOrValue<BigNumberish>,
     overrides: CallOverrides = {}
   ): Promise<string> {
-    return await this.contract.connect(provider).tokenURI(tokenId, { ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).tokenURI(tokenId, overrides);
   }
 
   /**
    * @returns returns the total amount of tokens stored by the contract.
    */
   public async totalSupply(provider: Provider, overrides: CallOverrides = {}): Promise<BigNumber> {
-    return await this.contract.connect(provider).totalSupply({ ...defaultGasOverrides, ...overrides });
+    return await this.contract.connect(provider).totalSupply(overrides);
   }
 
   /**


### PR DESCRIPTION
Bug raised from [slack thread](https://imtbl.slack.com/archives/C03KPP6T55Y/p1702445529405719)

Possibly [related issue](https://github.com/ethers-io/ethers.js/issues/1144)

**Issue 1**

Contract read functions are being processed as transactions when provided with gas config parameters, causing them to error. 

- Restored read functionality by removing these params
- Verified using local client on random `testnet` collection: `0x2b78f58db10873ba99f7e10ea643c3e232977a00`, output below

```
❯ npm run read
> mycontracts@1.0.0 read
> ./node_modules/.bin/ts-node read.ts

readFunctions()
--> MINTER_ROLE:  0x4d494e5445525f524f4c45000000000000000000000000000000000000000000
--> balanceOf:  3
--> ownerOf:  0x33273ef27D51F2D655c7eC33b66A40137368F5Fd
--> baseURI:  https://yellow-quickest-cuckoo-526.mypinata.cloud/ipfs/QmNvRoEzCiFpYxr7g1ZYKUQQZ77mMnh2J26HpxHfz6HfFL/?_gl=1*ygal58*_ga*NTc4OTQ4OTM2LjE3MDIyNzMxMjE.*_ga_5RMPXG14TE*MTcwMjQ0NjI4MC4yLjEuMTcwMjQ0ODI3OS42MC4wLjA./
```

**Issue 2**

When providing default `maxPriorityFeePerGas` and `maxFeePerGas`, `gasLimit` is also required

- Added `gasLimit` as per [chain configuration documentation](https://docs.immutable.com/docs/zkEVM/architecture/gas-config)

Verified by using local client to mint to a deployed collection on `testnet`:

https://explorer.testnet.immutable.com/address/0x52D733981d076374c149C7E6D72B9b7888632839

