### PR TITLE
[GMS-1325] Remove unnecessary build artefacts

### DIFF
--- a/clients/erc721-mint-by-id.ts
+++ b/clients/erc721-mint-by-id.ts
@@ -1,8 +1,11 @@
 import type { BigNumber, BigNumberish, BytesLike, CallOverrides, Overrides, PopulatedTransaction } from "ethers";
 import type { Provider } from "@ethersproject/providers";
 
-import { ImmutableERC721MintByID, ImmutableERC721MintByID__factory } from "../typechain-types";
-import { ImmutableERC721Base } from "../typechain-types/contracts/token/erc721/preset/ImmutableERC721MintByID";
+import { ImmutableERC721MintByID__factory } from "../typechain-types/factories/contracts/token/erc721/preset/ImmutableERC721MintByID__factory";
+import {
+  ImmutableERC721Base,
+  ImmutableERC721MintByID,
+} from "../typechain-types/contracts/token/erc721/preset/ImmutableERC721MintByID";
 import { PromiseOrValue } from "../typechain-types/common";
 import { defaultGasOverrides } from "./config/overrides";
 

--- a/clients/erc721.ts
+++ b/clients/erc721.ts
@@ -1,8 +1,8 @@
 import type { BigNumber, BigNumberish, BytesLike, CallOverrides, Overrides, PopulatedTransaction } from "ethers";
 import type { Provider } from "@ethersproject/providers";
 
-import { ImmutableERC721, ImmutableERC721__factory } from "../typechain-types";
-import { ERC721Hybrid } from "../typechain-types/contracts/token/erc721/preset/ImmutableERC721";
+import { ImmutableERC721__factory } from "../typechain-types/factories/contracts/token/erc721/preset/ImmutableERC721__factory";
+import { ImmutableERC721, ERC721Hybrid } from "../typechain-types/contracts/token/erc721/preset/ImmutableERC721";
 import { PromiseOrValue } from "../typechain-types/common";
 import { defaultGasOverrides } from "./config/overrides";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,5 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["./scripts", "./typechain", "./clients", "./test", "./index.ts", "./deploy"],
-  "files": ["./hardhat.config.ts"]
+  "include": ["./index.ts"]
 }


### PR DESCRIPTION
Removes unneeded files from build

exported `dist` folder is much smaller, however does contain the necessary files for generating clients:

```
npm notice 115B   dist/clients/config/overrides.d.ts
npm notice 339B   dist/clients/config/overrides.js
npm notice 2.1kB  dist/clients/erc20.d.ts
npm notice 2.2kB  dist/clients/erc20.js
npm notice 11.5kB dist/clients/erc721-mint-by-id.d.ts
npm notice 13.1kB dist/clients/erc721-mint-by-id.js
npm notice 14.0kB dist/clients/erc721.d.ts
npm notice 15.6kB dist/clients/erc721.js
npm notice 140B   dist/clients/index.d.ts
npm notice 679B   dist/clients/index.js
npm notice 27B    dist/index.d.ts
npm notice 802B   dist/index.js
npm notice 13.1kB dist/typechain-types/@openzeppelin/contracts/token/ERC20/ERC20.d.ts
npm notice 77B    dist/typechain-types/@openzeppelin/contracts/token/ERC20/ERC20.js
npm notice 10.5kB dist/typechain-types/@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.d.ts
npm notice 77B    dist/typechain-types/@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.js
npm notice 56B    dist/typechain-types/@openzeppelin/contracts/token/ERC20/extensions/index.d.ts
npm notice 77B    dist/typechain-types/@openzeppelin/contracts/token/ERC20/extensions/index.js
npm notice 8.9kB  dist/typechain-types/@openzeppelin/contracts/token/ERC20/IERC20.d.ts
npm notice 77B    dist/typechain-types/@openzeppelin/contracts/token/ERC20/IERC20.js
npm notice 155B   dist/typechain-types/@openzeppelin/contracts/token/ERC20/index.d.ts
npm notice 77B    dist/typechain-types/@openzeppelin/contracts/token/ERC20/index.js
npm notice 1.1kB  dist/typechain-types/common.d.ts
npm notice 77B    dist/typechain-types/common.js
npm notice 64.3kB dist/typechain-types/contracts/token/erc721/preset/ImmutableERC721.d.ts
npm notice 77B    dist/typechain-types/contracts/token/erc721/preset/ImmutableERC721.js
npm notice 59.9kB dist/typechain-types/contracts/token/erc721/preset/ImmutableERC721MintByID.d.ts
npm notice 77B    dist/typechain-types/contracts/token/erc721/preset/ImmutableERC721MintByID.js
npm notice 14.1kB dist/typechain-types/factories/@openzeppelin/contracts/token/ERC20/ERC20__factory.d.ts
npm notice 13.6kB dist/typechain-types/factories/@openzeppelin/contracts/token/ERC20/ERC20__factory.js
npm notice 85.7kB dist/typechain-types/factories/contracts/token/erc721/preset/ImmutableERC721__factory.d.ts
npm notice 82.8kB dist/typechain-types/factories/contracts/token/erc721/preset/ImmutableERC721__factory.js
npm notice 74.4kB dist/typechain-types/factories/contracts/token/erc721/preset/ImmutableERC721MintByID__factory.d.ts
npm notice 71.5kB dist/typechain-types/factories/contracts/token/erc721/preset/ImmutableERC721MintByID__factory.js
npm notice 2.2kB  package.json
```