### PR TITLE
Switch to granular scoped token

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -61,6 +61,6 @@ jobs:
       - name: Publish package
         uses: JS-DevTools/npm-publish@v1
         with:
-          token: ${{ secrets.PLATFORM_SA_NPM_TOKEN }}
+          token: ${{ secrets.CONTRACTS_NPM_TOKEN }}
           access: public
           tag: "latest"


### PR DESCRIPTION
Old token will not work with public repos, granular token scoped to single permission set and package