### PR TITLE
[TD-1114] Make ImmutableSeaport and ImmutableSignedZone ownership configurable through constructor

### DIFF
--- a/contracts/trading/seaport/ImmutableSeaport.sol
+++ b/contracts/trading/seaport/ImmutableSeaport.sol
@@ -14,7 +14,7 @@ import {
     OrderComponents
 } from "seaport-types/src/lib/ConsiderationStructs.sol";
 import { OrderType } from "seaport-types/src/lib/ConsiderationEnums.sol";
-import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import {
     ImmutableSeaportEvents
 } from "./interfaces/ImmutableSeaportEvents.sol";
@@ -31,7 +31,7 @@ import {
  */
 contract ImmutableSeaport is
     Consideration,
-    Ownable2Step,
+    Ownable,
     ImmutableSeaportEvents
 {
     // Mapping to store valid ImmutableZones - this allows for multiple Zones
@@ -48,10 +48,16 @@ contract ImmutableSeaport is
      * @param conduitController A contract that deploys conduits, or proxies
      *                          that may optionally be used to transfer approved
      *                          ERC20/721/1155 tokens.
+     * @param owner             The address of the owner of this contract. Specified in the
+     *                          constructor to be CREATE2 / CREATE3 compatible.
      */
     constructor(
-        address conduitController
-    ) Consideration(conduitController) Ownable2Step() {}
+        address conduitController,
+        address owner
+    ) Consideration(conduitController) Ownable() {
+        // Transfer ownership to the address specified in the constructor
+        _transferOwnership(owner);
+    }
 
     /**
      * @dev Set the validity of a zone for use during fulfillment.

--- a/contracts/trading/seaport/zones/ImmutableSignedZone.sol
+++ b/contracts/trading/seaport/zones/ImmutableSignedZone.sol
@@ -12,7 +12,7 @@ import { SIP7Interface } from "./interfaces/SIP7Interface.sol";
 import { SIP7EventsAndErrors } from "./interfaces/SIP7EventsAndErrors.sol";
 import { SIP6EventsAndErrors } from "./interfaces/SIP6EventsAndErrors.sol";
 import { SIP5Interface } from "./interfaces/SIP5Interface.sol";
-import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { ERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -40,7 +40,7 @@ contract ImmutableSignedZone is
     ZoneInterface,
     SIP5Interface,
     SIP7Interface,
-    Ownable2Step
+    Ownable
 {
     /// @dev The EIP-712 digest parameters.
     bytes32 internal immutable _VERSION_HASH = keccak256(bytes("1.0"));
@@ -115,11 +115,14 @@ contract ImmutableSignedZone is
      * @param apiEndpoint The API endpoint where orders for this zone can be
      *                    signed.
      *                    Request and response payloads are defined in SIP-7.
+     * @param owner       The address of the owner of this contract. Specified in the
+     *                    constructor to be CREATE2 / CREATE3 compatible.
      */
     constructor(
         string memory zoneName,
         string memory apiEndpoint,
-        string memory documentationURI
+        string memory documentationURI,
+        address owner
     ) {
         // Set the zone name.
         _ZONE_NAME = zoneName;
@@ -135,6 +138,9 @@ contract ImmutableSignedZone is
 
         // Emit an event to signal a SIP-5 contract has been deployed.
         emit SeaportCompatibleContractDeployed();
+
+        // Transfer ownership to the address specified in the constructor
+        _transferOwnership(owner);
     }
 
     /**

--- a/test/seaport/immutablesignedzone.test.ts
+++ b/test/seaport/immutablesignedzone.test.ts
@@ -36,7 +36,7 @@ describe("ImmutableSignedZone", function () {
     users = await ethers.getSigners();
     deployer = users[0];
     const factory = await ethers.getContractFactory("ImmutableSignedZone");
-    const tx = await factory.connect(deployer).deploy("ImmutableSignedZone", "", "");
+    const tx = await factory.connect(deployer).deploy("ImmutableSignedZone", "", "", deployer.address);
 
     const address = (await tx.deployed()).address;
 
@@ -44,17 +44,15 @@ describe("ImmutableSignedZone", function () {
   });
 
   describe("Ownership", async function () {
-    it("deployer beomces owner", async () => {
+    it("deployer becomes owner", async () => {
       assert((await contract.owner()) === deployer.address);
     });
 
-    it("transferOwnership and acceptOwnership works", async () => {
+    it("transferOwnership works", async () => {
       assert((await contract.owner()) === deployer.address);
       const transferTx = await contract.connect(deployer).transferOwnership(users[2].address);
       await transferTx.wait(1);
 
-      const acceptTx = await contract.connect(users[2]).acceptOwnership();
-      await acceptTx.wait(1);
       assert((await contract.owner()) === users[2].address);
     });
 

--- a/test/seaport/utils/deploy-immutable-contracts.ts
+++ b/test/seaport/utils/deploy-immutable-contracts.ts
@@ -31,7 +31,8 @@ export async function deployImmutableContracts(serverSignerAddress: string): Pro
   const immutableSignedZoneContract = (await immutableSignedZoneFactory.deploy(
     "ImmutableSignedZone",
     "",
-    ""
+    "",
+    accounts[0].address
   )) as ImmutableSignedZone;
   await immutableSignedZoneContract.deployed();
 
@@ -47,7 +48,8 @@ export async function deployImmutableContracts(serverSignerAddress: string): Pro
 
   const seaportContractFactory = await hre.ethers.getContractFactory("ImmutableSeaport");
   const seaportContract = (await seaportContractFactory.deploy(
-    seaportConduitControllerContract.address
+    seaportConduitControllerContract.address,
+    accounts[0].address
   )) as ImmutableSeaport;
   await seaportContract.deployed();
 


### PR DESCRIPTION
This PR makes the owner an argument in the constructor to be configurable with `CREATE3` contract deployments.

`Ownable2Step` was replaced with `Ownable` so the ownership could be transferred in a single step during initalization. Our other contracts use `Ownable` so its more standard