### PR TITLE
fix: flakey yarn install by reducing network concurrency

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yarn install --frozen-lockfile
+          yarn install --frozen-lockfile --network-concurrency 1
 
       - name: Compile contracts
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --network-concurrency 2
+        run: yarn install --frozen-lockfile --network-concurrency 1
       - name: Run tests
         run: forge test -vvv
   hardhat-test:
@@ -31,7 +31,7 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --network-concurrency 2
+        run: yarn install --frozen-lockfile --network-concurrency 1
       - name: Run Tests
         run: yarn test
   lint:
@@ -46,7 +46,7 @@ jobs:
           node-version: lts/*
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --network-concurrency 2
+        run: yarn install --frozen-lockfile --network-concurrency 1
       - name: Run eslint
         run: yarn lint
   publish:
@@ -62,7 +62,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --network-concurrency 2
+        run: yarn install --frozen-lockfile --network-concurrency 1
       - name: Compile contracts
         run: yarn compile
       - name: Build dist files


### PR DESCRIPTION
Use lower network concurrency for improved CI stability. Also introduce flag on publishing which was missing it and therefore failing to run