### PR TITLE
chore: Add traders code ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,9 @@
 
 /contracts/allowlist @immutable/assets
 /contracts/token @immutable/assets
+/contracts/trading @immutable/traders
 
-/tests/allowlist @immutable/assets
-/tests/royalty-enforcement @immutable/assets
-/tests/token @immutable/assets
+/test/allowlist @immutable/assets
+/test/royalty-enforcement @immutable/assets
+/test/token @immutable/assets
+/test/seaport @immutable/traders


### PR DESCRIPTION
- Add code ownership of trading contract to traders team
- Fix code owernership of `test/` directy, which was incorrectly named as `tests/`