### PR TITLE
fix: npx for correct postinstall exec access

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "postinstall": "rimraf ./node_modules/seaport/foundry.toml",
+    "postinstall": "npx rimraf ./node_modules/seaport/foundry.toml",
     "compile": "hardhat compile",
     "build": "tsc",
     "test": "hardhat test",


### PR DESCRIPTION
The previous syntax worked with `npm` but not with `yarn`. Explicitly using `npx` to find the executable should fix the issue