### PR TITLE
chore: Initial shape of centralized place for all Deployed contract addresses

### DIFF
--- a/contract_address.json
+++ b/contract_address.json
@@ -1,5 +1,4 @@
 [
-    
     {
         "Contract Name": "ImmutableSigner",
         "Testnet Address": "0xcff469E561D9dCe5B1185CD2AC1Fa961F8fbDe61",
@@ -28,7 +27,7 @@
         ]
     },
     {
-        "Contract Name": "Factory",
+        "Contract Name": "Factory (Wallet Factory Contract)",
         "Testnet Address": "0x8Fa5088dF65855E0DaF87FA6591659893b24871d",
         "Mainnet Address": "0x8Fa5088dF65855E0DaF87FA6591659893b24871d",
         "Contract Code Link": "https://explorer.immutable.com/address/0x8Fa5088dF65855E0DaF87FA6591659893b24871d?tab=contract",

--- a/contract_address.json
+++ b/contract_address.json
@@ -29,9 +29,9 @@
         ]
     },
     {
-        "Contract Name": "Operator Allowlist",
-        "Testnet Address": "",
-        "Mainnet Address": "",
+        "Contract Name": "Operator Allowlist (OAL)",
+        "Testnet Address": "0x6b969FD89dE634d8DE3271EbE97734FEFfcd58eE",
+        "Mainnet Address": "0x5F5EBa8133f68ea22D712b0926e2803E78D89221",
         "Contract Code Link": "",
         "Tags": [
             "assets"
@@ -39,20 +39,13 @@
     },
     {
         "Contract Name": "Contract Factory",
-        "Testnet Address": "",
-        "Mainnet Address": "",
+        "Testnet Address": "0x3CC6ee9c987458a0D9f69e49c87816F7DAcA2c19",
+        "Mainnet Address": "0x612D0C4b92a079D7603C2D898128a72262A141B3",
         "Contract Code Link": "",
         "Tags": [
-            "hub"
-        ]
-    },
-    {
-        "Contract Name": "ERC721 Preset",
-        "Testnet Address": "",
-        "Mainnet Address": "",
-        "Contract Code Link": "",
-        "Tags": [
-            "hub"
+            "hub",
+            "oal",
+            "allowlist"
         ]
     },
     {

--- a/contract_address.json
+++ b/contract_address.json
@@ -1,0 +1,135 @@
+[
+    {
+        "Contract Name": "Zone Contract",
+        "Testnet Address": "0x8831867E347AB87FA30199C5B695F0A31604Bb52",
+        "Mainnet Address": "0x00338b92Bec262078B3e49BF12bbEA058916BF91",
+        "Contract Code Link": "",
+        "Tags": ["traders"]
+    },
+    {
+        "Contract Name": "Zone Signer",
+        "Testnet Address": "0x539E1Aa6f2063D8674088fBb0b1aE247Ba1B096b",
+        "Mainnet Address": "0x71f83d1616d1E020053d5d9Ba5CBd385693C2955",
+        "Contract Code Link": "",
+        "Tags": ["traders"]
+    },
+    {
+        "Contract Name": "Read Only Order Validator",
+        "Testnet Address": "0x617F14b4695B8bD24F11e5d157B960786fe37F5D",
+        "Mainnet Address": "0x75DCc1226533A39d41C5578feeAdc37D57916c08",
+        "Contract Code Link": "",
+        "Tags": ["traders"]
+    },
+    {
+        "Contract Name": "Seaport Validator",
+        "Testnet Address": "0x47E927CdcCC7828db2D046d34706660537670F0F",
+        "Mainnet Address": "0x7dd422357E860bbED7d992C276a54D44cD179818",
+        "Contract Code Link": "",
+        "Tags": ["traders", "allowlist"]
+    },
+    {
+        "Contract Name": "Seaport Contract",
+        "Testnet Address": "0x7d117aA8BD6D31c4fa91722f246388f38ab1942c",
+        "Mainnet Address": "0x6c12aD6F0bD274191075Eb2E78D7dA5ba6453424",
+        "Contract Code Link": "",
+        "Tags": ["traders", "allowlist"]
+    },
+    {
+        "Contract Name": "Operator Allowlist",
+        "Testnet Address": "",
+        "Mainnet Address": "",
+        "Contract Code Link": "",
+        "Tags": ["assets"]
+    },
+    {
+        "Contract Name": "V3 Factory",
+        "Testnet Address": "0x56c2162254b0E4417288786eE402c2B41d4e181e",
+        "Mainnet Address": "0x56c2162254b0E4417288786eE402c2B41d4e181e",
+        "Contract Code Link": "",
+        "Tags": ["tokens"]
+    },
+    {
+        "Contract Name": "UniswapInterfaceMulticall",
+        "Testnet Address": "0x4857Dfd11c712e862eC362cEee29F7974B70EfcD",
+        "Mainnet Address": "0xc7efb32470dEE601959B15f1f923e017C6A918cA",
+        "Contract Code Link": "",
+        "Tags": ["tokens"]
+    },
+    {
+        "Contract Name": "SwapRouter02",
+        "Testnet Address": "0x0b012055F770AE7BB7a8303968A7Fb6088A2296e",
+        "Mainnet Address": "0xE5a02c2Be08406c3fB36F9Aa29bF7C7A09CAe50B",
+        "Contract Code Link": "",
+        "Tags": ["tokens"]
+    },
+    {
+        "Contract Name": "QuoterV2",
+        "Testnet Address": "0xF6Ad3CcF71Abb3E12beCf6b3D2a74C963859ADCd",
+        "Mainnet Address": "0xF6Ad3CcF71Abb3E12beCf6b3D2a74C963859ADCd",
+        "Contract Code Link": "",
+        "Tags": ["tokens"]
+    },
+    {
+        "Contract Name": "NonFungiblePositionManager",
+        "Testnet Address": "0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff",
+        "Mainnet Address": "0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff",
+        "Contract Code Link": "",
+        "Tags": ["tokens"]
+    },
+    {
+        "Contract Name": "NonFungibleTokenPositionDescriptor",
+        "Testnet Address": "0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32",
+        "Mainnet Address": "0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32",
+        "Contract Code Link": "",
+        "Tags": ["tokens"]
+    },
+    {
+        "Contract Name": "TickLens",
+        "Testnet Address": "0xd2480162Aa7F02Ead7BF4C127465446150D58452",
+        "Mainnet Address": "0xd2480162Aa7F02Ead7BF4C127465446150D58452",
+        "Contract Code Link": "",
+        "Tags": ["tokens"]
+    },
+    {
+        "Contract Name": "Contract Factory",
+        "Testnet Address": "",
+        "Mainnet Address": "",
+        "Contract Code Link": "",
+        "Tags": ["hub"]
+    },
+    {
+        "Contract Name": "ERC721 Preset",
+        "Testnet Address": "",
+        "Mainnet Address": "",
+        "Contract Code Link": "",
+        "Tags": ["hub"]
+    },
+    {
+        "Contract Name": "",
+        "Testnet Address": "",
+        "Mainnet Address": "",
+        "Contract Code Link": "",
+        "Tags": [""]
+    },
+    {
+        "Contract Name": "",
+        "Testnet Address": "",
+        "Mainnet Address": "",
+        "Contract Code Link": "",
+        "Tags": [""]
+    },
+    {
+        "Contract Name": "",
+        "Testnet Address": "",
+        "Mainnet Address": "",
+        "Contract Code Link": "",
+        "Tags": [""]
+    },
+    {
+        "Contract Name": "",
+        "Testnet Address": "",
+        "Mainnet Address": "",
+        "Contract Code Link": "",
+        "Tags": [""]
+    }
+]

--- a/contract_address.json
+++ b/contract_address.json
@@ -4,104 +4,73 @@
         "Testnet Address": "0x8831867E347AB87FA30199C5B695F0A31604Bb52",
         "Mainnet Address": "0x00338b92Bec262078B3e49BF12bbEA058916BF91",
         "Contract Code Link": "",
-        "Tags": ["traders"]
+        "Tags": [
+            "traders"
+        ]
     },
     {
         "Contract Name": "Seaport Validator",
         "Testnet Address": "0x47E927CdcCC7828db2D046d34706660537670F0F",
         "Mainnet Address": "0x7dd422357E860bbED7d992C276a54D44cD179818",
         "Contract Code Link": "",
-        "Tags": ["traders", "allowlist"]
+        "Tags": [
+            "traders",
+            "allowlist"
+        ]
     },
     {
         "Contract Name": "Seaport Contract",
         "Testnet Address": "0x7d117aA8BD6D31c4fa91722f246388f38ab1942c",
         "Mainnet Address": "0x6c12aD6F0bD274191075Eb2E78D7dA5ba6453424",
         "Contract Code Link": "",
-        "Tags": ["traders", "allowlist"]
+        "Tags": [
+            "traders",
+            "allowlist"
+        ]
     },
     {
         "Contract Name": "Operator Allowlist",
         "Testnet Address": "",
         "Mainnet Address": "",
         "Contract Code Link": "",
-        "Tags": ["assets"]
-    },
-    {
-        "Contract Name": "V3 Factory",
-        "Testnet Address": "0x56c2162254b0E4417288786eE402c2B41d4e181e",
-        "Mainnet Address": "0x56c2162254b0E4417288786eE402c2B41d4e181e",
-        "Contract Code Link": "",
-        "Tags": ["tokens"]
-    },
-    {
-        "Contract Name": "UniswapInterfaceMulticall",
-        "Testnet Address": "0x4857Dfd11c712e862eC362cEee29F7974B70EfcD",
-        "Mainnet Address": "0xc7efb32470dEE601959B15f1f923e017C6A918cA",
-        "Contract Code Link": "",
-        "Tags": ["tokens"]
-    },
-    {
-        "Contract Name": "SwapRouter02",
-        "Testnet Address": "0x0b012055F770AE7BB7a8303968A7Fb6088A2296e",
-        "Mainnet Address": "0xE5a02c2Be08406c3fB36F9Aa29bF7C7A09CAe50B",
-        "Contract Code Link": "",
-        "Tags": ["tokens"]
-    },
-    {
-        "Contract Name": "QuoterV2",
-        "Testnet Address": "0xF6Ad3CcF71Abb3E12beCf6b3D2a74C963859ADCd",
-        "Mainnet Address": "0xF6Ad3CcF71Abb3E12beCf6b3D2a74C963859ADCd",
-        "Contract Code Link": "",
-        "Tags": ["tokens"]
-    },
-    {
-        "Contract Name": "NonFungiblePositionManager",
-        "Testnet Address": "0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff",
-        "Mainnet Address": "0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff",
-        "Contract Code Link": "",
-        "Tags": ["tokens"]
-    },
-    {
-        "Contract Name": "NonFungibleTokenPositionDescriptor",
-        "Testnet Address": "0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32",
-        "Mainnet Address": "0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32",
-        "Contract Code Link": "",
-        "Tags": ["tokens"]
-    },
-    {
-        "Contract Name": "TickLens",
-        "Testnet Address": "0xd2480162Aa7F02Ead7BF4C127465446150D58452",
-        "Mainnet Address": "0xd2480162Aa7F02Ead7BF4C127465446150D58452",
-        "Contract Code Link": "",
-        "Tags": ["tokens"]
+        "Tags": [
+            "assets"
+        ]
     },
     {
         "Contract Name": "Contract Factory",
         "Testnet Address": "",
         "Mainnet Address": "",
         "Contract Code Link": "",
-        "Tags": ["hub"]
+        "Tags": [
+            "hub"
+        ]
     },
     {
         "Contract Name": "ERC721 Preset",
         "Testnet Address": "",
         "Mainnet Address": "",
         "Contract Code Link": "",
-        "Tags": ["hub"]
+        "Tags": [
+            "hub"
+        ]
+    },
+    {
+        "Contract Name": "ImmutableSwapProxy",
+        "Testnet Address": "0xDdBDa144cEbe1cCd68E746CDff8a6e4Be51A9e98",
+        "Mainnet Address": "0xD67cc11151dBccCC424A16F8963ece3D0539BD61",
+        "Contract Code Link": "",
+        "Tags": [
+            "tokens"
+        ]
     },
     {
         "Contract Name": "",
         "Testnet Address": "",
         "Mainnet Address": "",
         "Contract Code Link": "",
-        "Tags": [""]
-    },
-    {
-        "Contract Name": "",
-        "Testnet Address": "",
-        "Mainnet Address": "",
-        "Contract Code Link": "",
-        "Tags": [""]
+        "Tags": [
+            ""
+        ]
     }
 ]

--- a/contract_address.json
+++ b/contract_address.json
@@ -1,22 +1,8 @@
 [
     {
-        "Contract Name": "Zone Contract",
+        "Contract Name": "ImmutableSignedZoneContract",
         "Testnet Address": "0x8831867E347AB87FA30199C5B695F0A31604Bb52",
         "Mainnet Address": "0x00338b92Bec262078B3e49BF12bbEA058916BF91",
-        "Contract Code Link": "",
-        "Tags": ["traders"]
-    },
-    {
-        "Contract Name": "Zone Signer",
-        "Testnet Address": "0x539E1Aa6f2063D8674088fBb0b1aE247Ba1B096b",
-        "Mainnet Address": "0x71f83d1616d1E020053d5d9Ba5CBd385693C2955",
-        "Contract Code Link": "",
-        "Tags": ["traders"]
-    },
-    {
-        "Contract Name": "Read Only Order Validator",
-        "Testnet Address": "0x617F14b4695B8bD24F11e5d157B960786fe37F5D",
-        "Mainnet Address": "0x75DCc1226533A39d41C5578feeAdc37D57916c08",
         "Contract Code Link": "",
         "Tags": ["traders"]
     },
@@ -103,20 +89,6 @@
         "Mainnet Address": "",
         "Contract Code Link": "",
         "Tags": ["hub"]
-    },
-    {
-        "Contract Name": "",
-        "Testnet Address": "",
-        "Mainnet Address": "",
-        "Contract Code Link": "",
-        "Tags": [""]
-    },
-    {
-        "Contract Name": "",
-        "Testnet Address": "",
-        "Mainnet Address": "",
-        "Contract Code Link": "",
-        "Tags": [""]
     },
     {
         "Contract Name": "",

--- a/contract_address.json
+++ b/contract_address.json
@@ -1,4 +1,41 @@
 [
+    
+    {
+        "Contract Name": "ImmutableSigner",
+        "Testnet Address": "0xcff469E561D9dCe5B1185CD2AC1Fa961F8fbDe61",
+        "Mainnet Address": "0xcff469E561D9dCe5B1185CD2AC1Fa961F8fbDe61",
+        "Contract Code Link": "https://explorer.immutable.com/address/0xcff469E561D9dCe5B1185CD2AC1Fa961F8fbDe61#code",
+        "Tags": [
+            "rollups"
+        ]
+    },
+    {
+        "Contract Name": "StartupWalletImpl",
+        "Testnet Address": "0x8FD900677aabcbB368e0a27566cCd0C7435F1926",
+        "Mainnet Address": "0x8FD900677aabcbB368e0a27566cCd0C7435F1926",
+        "Contract Code Link": "https://explorer.immutable.com/address/0x8FD900677aabcbB368e0a27566cCd0C7435F1926?tab=contract",
+        "Tags": [
+            "rollups"
+        ]
+    },
+    {
+        "Contract Name": "ChildERC20Bridge",
+        "Testnet Address": "",
+        "Mainnet Address": "0xb4c3597e6b090A2f6117780cEd103FB16B071A84",
+        "Contract Code Link": "https://explorer.immutable.com/address/0xb4c3597e6b090A2f6117780cEd103FB16B071A84?tab=contract",
+        "Tags": [
+            "rollups"
+        ]
+    },
+    {
+        "Contract Name": "Factory",
+        "Testnet Address": "0x8Fa5088dF65855E0DaF87FA6591659893b24871d",
+        "Mainnet Address": "0x8Fa5088dF65855E0DaF87FA6591659893b24871d",
+        "Contract Code Link": "https://explorer.immutable.com/address/0x8Fa5088dF65855E0DaF87FA6591659893b24871d?tab=contract",
+        "Tags": [
+            "rollups"
+        ]
+    },
     {
         "Contract Name": "ImmutableSignedZoneContract",
         "Testnet Address": "0x8831867E347AB87FA30199C5B695F0A31604Bb52",
@@ -38,7 +75,7 @@
         ]
     },
     {
-        "Contract Name": "Contract Factory",
+        "Contract Name": "ContractFactory",
         "Testnet Address": "0x3CC6ee9c987458a0D9f69e49c87816F7DAcA2c19",
         "Mainnet Address": "0x612D0C4b92a079D7603C2D898128a72262A141B3",
         "Contract Code Link": "",
@@ -55,15 +92,6 @@
         "Contract Code Link": "",
         "Tags": [
             "tokens"
-        ]
-    },
-    {
-        "Contract Name": "",
-        "Testnet Address": "",
-        "Mainnet Address": "",
-        "Contract Code Link": "",
-        "Tags": [
-            ""
         ]
     }
 ]


### PR DESCRIPTION
**Problems to solve**: 
We would like one centralized place, publicly expose key contract addresses, so that we provide both confidence, trust and convenience to the builders and users in the community.
Currently, Immutable teams use Confluence or other alternatives to track deployed and verified contract addresses. They may or may not be up to date. No community members can see them from our public Docs. If they go to our chain exploer, since we deployed same thing multiple times, it's also not easy to see which ones are official.

**Solution**
* 1 json starts with most basic information about each contract that are useful in our ecosystem.
* Merge and publish this list ahead of Mainnet announcement.
* Short term will duplicate this information to a table on [docs.immutable.com](https://docs.immutable.com/) ZKevm Overview page.
* Long term, will automate pump this json info to where we need. Including potentially make an endpoint for this json to be available. Develop history tracking for it, and automation related to deployment. 

**Reviewers please:**
* give feedback to the schema of this json. Keep it simple and powerful, did it miss any critical info?
* add, remove, modify Contracts that your team is responsible for --- instead of updating address in your team's Confluence, use here as source of truth.