### PR TITLE
[TP-2147] Add Gem Game contract

### DIFF
--- a/contracts/games/gems/GemGame.sol
+++ b/contracts/games/gems/GemGame.sol
@@ -6,9 +6,9 @@ pragma solidity ^0.8.20;
  * @title GemGame - A simple contract that emits an event.
  */
 contract GemGame {
-    event GemEarned(address indexed account);
+    event GemEarned(address indexed account, uint256 timestamp);
 
     function earnGem() external {
-        emit GemEarned(msg.sender);
+        emit GemEarned(msg.sender, block.timestamp);
     }
 }

--- a/contracts/games/gems/GemGame.sol
+++ b/contracts/games/gems/GemGame.sol
@@ -1,6 +1,6 @@
 // Copyright (c) Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 /**
  * @title GemGame - A simple contract that emits an event for the purpose of indexing off-chain
@@ -15,6 +15,7 @@ contract GemGame {
      * @notice Function that emits a `GemEarned` event
      */
     function earnGem() external {
+        // solhint-disable-next-line not-rely-on-time
         emit GemEarned(msg.sender, block.timestamp);
     }
 }

--- a/contracts/games/gems/GemGame.sol
+++ b/contracts/games/gems/GemGame.sol
@@ -1,6 +1,6 @@
 // Copyright (c) Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2
-pragma solidity ^0.8.20;
+pragma solidity =0.8.20;
 
 /**
  * @title GemGame - A simple contract that emits an event.

--- a/contracts/games/gems/GemGame.sol
+++ b/contracts/games/gems/GemGame.sol
@@ -1,13 +1,18 @@
 // Copyright (c) Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2
-pragma solidity =0.8.20;
+pragma solidity ^0.8.20;
 
 /**
- * @title GemGame - A simple contract that emits an event.
+ * @title GemGame - A simple contract that emits an event for the purpose of indexing off-chain
+ * @dev The GemGame contract is not designed to be upgradeable or extended
  */
 contract GemGame {
+    /// @notice Indicates that an account has earned a gem
     event GemEarned(address indexed account, uint256 timestamp);
 
+    /**
+     * @notice Function that emits a `GemEarned` event
+     */
     function earnGem() external {
         emit GemEarned(msg.sender, block.timestamp);
     }

--- a/contracts/games/gems/GemGame.sol
+++ b/contracts/games/gems/GemGame.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 
 /**
  * @title GemGame - A simple contract that emits an event for the purpose of indexing off-chain
+ * @author Immutable
  * @dev The GemGame contract is not designed to be upgradeable or extended
  */
 contract GemGame {

--- a/contracts/games/gems/GemGame.sol
+++ b/contracts/games/gems/GemGame.sol
@@ -1,0 +1,14 @@
+// Copyright (c) Immutable Pty Ltd 2018 - 2024
+// SPDX-License-Identifier: Apache 2
+pragma solidity ^0.8.20;
+
+/**
+ * @title GemGame - A simple contract that emits an event.
+ */
+contract GemGame {
+    event GemEarned(address indexed account);
+
+    function earnGem() external {
+        emit GemEarned(msg.sender);
+    }
+}

--- a/contracts/games/gems/README.md
+++ b/contracts/games/gems/README.md
@@ -1,0 +1,1 @@
+# Gem (GM) Game

--- a/contracts/games/gems/README.md
+++ b/contracts/games/gems/README.md
@@ -1,1 +1,3 @@
 # Gem (GM) Game
+
+The GemGame contract emits a single event for the purpose of indexing off-chain.

--- a/contracts/games/gems/README.md
+++ b/contracts/games/gems/README.md
@@ -1,3 +1,18 @@
 # Gem (GM) Game
 
 The GemGame contract emits a single event for the purpose of indexing off-chain.
+
+## Immutable Contract Addresses
+
+| Environment/Network      | Deployment Address | Commit Hash |
+|--------------------------|--------------------|-------------|
+| imtbl-zkevm-testnet      | -                  | -           |
+| imtbl-zkevm-mainnet      | -                  | -           |
+
+# Status
+
+Contract threat models and audits:
+
+| Description               | Date             |Version Audited  | Link to Report |
+|---------------------------|------------------|-----------------|----------------|
+| Not audited and no threat model              | -                | -               | -              |

--- a/script/games/gems/DeployGemGame.sol
+++ b/script/games/gems/DeployGemGame.sol
@@ -1,0 +1,60 @@
+// Copyright (c) Immutable Pty Ltd 2018 - 2023
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {GemGame} from "../../../contracts/games/gems/GemGame.sol";
+
+/**
+ * @title IDeployer Interface
+ * @notice This interface defines the contract responsible for deploying and optionally initializing new contracts
+ *  via a specified deployment method.
+ * @dev Credit to axelarnetwork https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/interfaces/IDeployer.sol
+ */
+interface IDeployer {
+    function deploy(bytes memory bytecode, bytes32 salt) external payable returns (address deployedAddress_);
+    function deployAndInit(bytes memory bytecode, bytes32 salt, bytes calldata init)
+        external
+        payable
+        returns (address deployedAddress_);
+    function deployedAddress(bytes calldata bytecode, address sender, bytes32 salt)
+        external
+        view
+        returns (address deployedAddress_);
+}
+
+struct DeploymentArgs {
+    address signer;
+    address deployer;
+    string salt;
+}
+
+contract DeployGemGame is Test {
+    function deploy() external {
+        address signer = vm.envAddress("DEPLOYER_ADDRESS");
+        address deployer = vm.envAddress("OWNABLE_CREATE3_FACTORY_ADDRESS");
+        string memory salt = vm.envString("GEM_GAME_SALT");
+
+        DeploymentArgs memory deploymentArgs = DeploymentArgs({signer: signer, deployer: deployer, salt: salt});
+
+        _deploy(deploymentArgs);
+    }
+
+    function _deploy(DeploymentArgs memory args) internal returns (GemGame gemGameContract) {
+        IDeployer ownableCreate3 = IDeployer(args.deployer);
+
+        // Create deployment bytecode and encode constructor args
+        bytes memory bytecode = abi.encodePacked(type(GemGame).creationCode);
+
+        bytes32 saltBytes = keccak256(abi.encode(args.salt));
+
+        /// @dev Deploy the contract via the Ownable CREATE3 factory
+        vm.startBroadcast(args.signer);
+
+        address gemGameContractAddress = ownableCreate3.deploy(bytecode, saltBytes);
+        gemGameContract = GemGame(gemGameContractAddress);
+
+        vm.stopBroadcast();
+    }
+}

--- a/test/games/gems/GemGame.t.sol
+++ b/test/games/gems/GemGame.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity =0.8.20;
+pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";
 import {GemGame} from "../../../contracts/games/gems/GemGame.sol";

--- a/test/games/gems/GemGame.t.sol
+++ b/test/games/gems/GemGame.t.sol
@@ -1,0 +1,22 @@
+// Copyright Immutable Pty Ltd 2018 - 2024
+// SPDX-License-Identifier: Apache 2.0
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {GemGame} from "../../../contracts/games/gems/GemGame.sol";
+
+contract GemGameTest is Test {
+    event GemEarned(address indexed account, uint256 timestamp);
+
+    GemGame gemGame;
+
+    function setUp() public {
+        gemGame = new GemGame();
+    }
+
+    function testEarnGem_EmitsGemEarnedEvent() public {
+        vm.expectEmit(true, true, false, false);
+        emit GemEarned(address(this), block.timestamp);
+        gemGame.earnGem();
+    }
+}

--- a/test/games/gems/GemGame.t.sol
+++ b/test/games/gems/GemGame.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.20;
+pragma solidity =0.8.20;
 
 import "forge-std/Test.sol";
 import {GemGame} from "../../../contracts/games/gems/GemGame.sol";


### PR DESCRIPTION
Adds a new contract - `GemGame`.

This contract includes a single function which emits an event. This event is intended to be indexed off-chain.