### PR TITLE
[NO-JIRA] Using oz burnable preset

### DIFF
--- a/contracts/token/erc20/preset/ImmutableERC20.sol
+++ b/contracts/token/erc20/preset/ImmutableERC20.sol
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import {ERC20Permit, ERC20} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {MintingAccessControl} from "../../../access/MintingAccessControl.sol";
@@ -17,7 +18,7 @@ import {IImmutableERC20Errors} from "../../../errors/ERC20Errors.sol";
  *  function. The Immutable Hub uses this function to help associate the ERC 20 contract 
  *  with a specific Immutable Hub account.
  */
-contract ImmutableERC20 is Ownable, ERC20Permit, MintingAccessControl {
+contract ImmutableERC20 is Ownable, ERC20Burnable, ERC20Permit, MintingAccessControl {
     uint256 private immutable _maxSupply;
 
     /**
@@ -47,14 +48,6 @@ contract ImmutableERC20 is Ownable, ERC20Permit, MintingAccessControl {
             revert IImmutableERC20Errors.MaxSupplyExceeded(_maxSupply);
         }
         _mint(to, amount);
-    }
-
-    /**
-     * @dev Burns `amount` number of tokens from the `from` address.
-     * @param amount the amount of tokens to burn.
-     */
-    function burn(uint256 amount) external {
-        _burn(msg.sender, amount);
     }
 
     /** 

--- a/test/token/erc20/preset/ImmutableERC20.t.sol
+++ b/test/token/erc20/preset/ImmutableERC20.t.sol
@@ -79,6 +79,22 @@ contract ImmutableERC20Test is Test {
         assertEq(erc20.balanceOf(tokenReceiver), 0);
     }
 
+    function testBurnFrom() public {
+        address burner = makeAddr("burner");
+        uint256 amount = 100;
+        vm.prank(minter);
+        erc20.mint(tokenReceiver, amount);
+        assertEq(erc20.balanceOf(tokenReceiver), 100);
+        vm.prank(burner);
+        vm.expectRevert("ERC20: insufficient allowance");
+        erc20.burnFrom(tokenReceiver, amount);
+        vm.prank(tokenReceiver);
+        erc20.approve(burner, 100);
+        vm.prank(burner);
+        erc20.burnFrom(tokenReceiver, amount);
+        assertEq(erc20.balanceOf(tokenReceiver), 0);
+    }
+
     function testCanOnlyMintUpToMaxSupply() public {
         address to = makeAddr("to");
         uint256 amount = 1000;


### PR DESCRIPTION
Added OZ's `ERC20Burnable` dependency which gives you `burn()` and `burnFrom()` as standard burn functions. This simplifies `ImmutableERC20` contract enabling the existing `burn()` function to be removed. 

Added a test `testBurnFrom()` which ensures you need approval before using `burnFrom()`. It tests the happy and unhappy paths.

You can run the test with;
```
forge test --match-test testBurnFrom -vvvvv
```