### PR TITLE
Enable more flexible access controls for contract deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage.json
 typechain
 typechain-types
 node.json
+.idea/
 
 # Hardhat files
 cache

--- a/contracts/deployer/AccessControlledDeployer.sol
+++ b/contracts/deployer/AccessControlledDeployer.sol
@@ -108,7 +108,7 @@ contract AccessControlledDeployer is AccessControlEnumerable, Pausable {
     }
 
     /**
-     * @notice Revokes the DEPLOYER_ROLE for a list of addresses
+     * @notice Revokes the DEPLOYER_ROLE from a list of addresses
      * @param deployers list of addresses to revoke the DEPLOYER_ROLE from
      * @dev Only address with DEFAULT_ADMIN_ROLE can call this function
      * @dev The function emits `RoleRevoked` event for each address for which the DEPLOYER_ROLE was revoked
@@ -132,6 +132,7 @@ contract AccessControlledDeployer is AccessControlEnumerable, Pausable {
      * @param newOwner The new owner of the deployer contract
      * @dev Only address with DEFAULT_ADMIN_ROLE can call this function
      * @dev This function requires that the current owner of `ownableDeployer` is this contract
+     * @dev The function emits `OwnershipTransferred` event if the ownership is successfully transferred
      */
     function transferOwnershipOfDeployer(
         Ownable ownableDeployer,

--- a/contracts/deployer/AccessControlledDeployer.sol
+++ b/contracts/deployer/AccessControlledDeployer.sol
@@ -1,0 +1,139 @@
+// Copyright Immutable Pty Ltd 2018 - 2024
+// SPDX-License-Identifier: Apache 2.0
+pragma solidity 0.8.19;
+
+import {IDeployer} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IDeployer.sol";
+import {Pausable} from "@openzeppelin/contracts/security/Pausable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {AccessControlEnumerable} from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
+
+contract AccessControlledDeployer is AccessControlEnumerable, Pausable {
+    /// @notice Role identifier for those who can pause the deployer
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER");
+
+    /// @notice Role identifier for those who can unpause the deployer
+    bytes32 public constant UNPAUSER_ROLE = keccak256("UNPAUSER");
+
+    /// @notice Role identifier for those who can deploy contracts
+    bytes32 public constant DEPLOYER_ROLE = keccak256("DEPLOYER");
+
+    /**
+     * @notice Construct a new RBACDeployer contract
+     * @param admin The address to grant the DEFAULT_ADMIN_ROLE
+     * @param pauser The address to grant the PAUSER_ROLE
+     * @param unpauser The address to grant the UNPAUSER_ROLE
+     */
+    constructor(address admin, address pauser, address unpauser) {
+        require(admin != address(0), "admin is the zero address");
+        require(pauser != address(0), "pauser is the zero address");
+        require(unpauser != address(0), "unpauser is the zero address");
+
+        _setupRole(DEFAULT_ADMIN_ROLE, admin);
+        _setupRole(PAUSER_ROLE, pauser);
+        _setupRole(UNPAUSER_ROLE, unpauser);
+    }
+
+    /**
+     * @notice Deploys a contract using a deployment method defined by `deployer`
+     * @param deployer The create2 or create3 deployer contract that will deploy the contract
+     * @param bytecode The bytecode of the contract to be deployed
+     * @param salt A salt to influence the contract address
+     * @dev Only address with DEPLOYER_ROLE can call this function
+     * @dev The function can only be called if the contract is not in a paused state
+     * @return The address of the deployed contract
+     */
+    function deploy(IDeployer deployer, bytes memory bytecode, bytes32 salt)
+        external
+        payable
+        whenNotPaused
+        onlyRole(DEPLOYER_ROLE)
+        returns (address)
+    {
+        require(address(deployer) != address(0), "deployer contract is the zero address");
+        return deployer.deploy(bytecode, salt);
+    }
+
+    /**
+     * @notice Deploys a contract using a deployment method defined by `deployer` and initializes it
+     * @param deployer The create2 or create3 deployer contract that will deploy the contract
+     * @param bytecode The bytecode of the contract to be deployed
+     * @param salt A salt to influence the contract address
+     * @param init Init data used to initialize the deployed contract
+     * @dev Only address with DEPLOYER_ROLE can call this function
+     * @dev The function can only be called if the contract is not in a paused state
+     * @return The address of the deployed contract
+     */
+    function deployAndInit(IDeployer deployer, bytes memory bytecode, bytes32 salt, bytes calldata init)
+        external
+        payable
+        whenNotPaused
+        onlyRole(DEPLOYER_ROLE)
+        returns (address)
+    {
+        require(address(deployer) != address(0), "deployer contract is the zero address");
+        return deployer.deployAndInit{value: msg.value}(bytecode, salt, init);
+    }
+
+    /**
+     * @notice Grants a list of addresses the DEPLOYER_ROLE
+     * @param deployers list of addresses to grant the DEPLOYER_ROLE
+     * @dev Only address with DEFAULT_ADMIN_ROLE can call this function
+     * @dev The function emits `RoleGranted` event for each address granted the DEPLOYER_ROLE.
+     *      This is not emitted if an address is already a deployer
+     */
+    function grantDeployerRole(address[] memory deployers) public {
+        require(deployers.length > 0, "deployers list is empty");
+        for (uint256 i = 0; i < deployers.length; i++) {
+            require(deployers[i] != address(0), "deployer is the zero address");
+            grantRole(DEPLOYER_ROLE, deployers[i]);
+        }
+    }
+
+    /**
+     * @notice Revokes the DEPLOYER_ROLE for a list of addresses
+     * @param deployers list of addresses to revoke the DEPLOYER_ROLE from
+     * @dev Only address with DEFAULT_ADMIN_ROLE can call this function
+     * @dev The function emits `RoleRevoked` event for each address for which the DEPLOYER_ROLE was revoked
+     *      This is not emitted if an address was not a deployer
+     */
+    function revokeDeployerRole(address[] memory deployers) public {
+        require(deployers.length > 0, "deployers list is empty");
+        for (uint256 i = 0; i < deployers.length; i++) {
+            require(deployers[i] != address(0), "deployer is the zero address");
+            revokeRole(DEPLOYER_ROLE, deployers[i]);
+        }
+    }
+
+    /**
+     * @notice Transfers the ownership of `ownableDeployer` from this contract to `newOwner`
+     * @param ownableDeployer The create2 or create3 ownable deployer contract to change the owner of
+     * @param newOwner The new owner of the deployer contract
+     * @dev Only address with DEFAULT_ADMIN_ROLE can call this function
+     * @dev This function requires that the current owner of `ownableDeployer` is this contract
+     */
+    function transferOwnershipOfDeployer(Ownable ownableDeployer, address newOwner)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        require(address(ownableDeployer) != address(0), "deployer contract is the zero address");
+        require(newOwner != address(0), "new owner is the zero address");
+        require(ownableDeployer.owner() == address(this), "deployer contract is not owned by this contract");
+        ownableDeployer.transferOwnership(newOwner);
+    }
+
+    /**
+     * @notice Pause the contract, preventing any new deployments
+     * @dev Only PAUSER_ROLE can call this function
+     */
+    function pause() external onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    /**
+     * @notice Unpause the contract if it was paused, re-enabling new deployments
+     * @dev Only UNPAUSER_ROLE can call this function
+     */
+    function unpause() external onlyRole(UNPAUSER_ROLE) {
+        _unpause();
+    }
+}

--- a/contracts/deployer/create/OwnableCreateDeploy.sol
+++ b/contracts/deployer/create/OwnableCreateDeploy.sol
@@ -22,7 +22,6 @@ contract OwnableCreateDeploy {
      * @param bytecode The bytecode of the contract to be deployed
      */
     // slither-disable-next-line locked-ether
-
     function deploy(bytes memory bytecode) external payable {
         // solhint-disable-next-line custom-errors
         require(msg.sender == owner, "CreateDeploy: caller is not the owner");

--- a/contracts/deployer/create/OwnableCreateDeploy.sol
+++ b/contracts/deployer/create/OwnableCreateDeploy.sol
@@ -22,6 +22,7 @@ contract OwnableCreateDeploy {
      * @param bytecode The bytecode of the contract to be deployed
      */
     // slither-disable-next-line locked-ether
+
     function deploy(bytes memory bytecode) external payable {
         // solhint-disable-next-line custom-errors
         require(msg.sender == owner, "CreateDeploy: caller is not the owner");

--- a/test/deployer/AccessControlledDeployer.t.sol
+++ b/test/deployer/AccessControlledDeployer.t.sol
@@ -26,6 +26,10 @@ contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
 
     event Deployed(address indexed deployedAddress, address indexed sender, bytes32 indexed salt, bytes32 bytecodeHash);
 
+    error ZeroAddress();
+    error EmptyDeployerList();
+    error NotOwnerOfDeployer();
+
     function setUp() public {
         rbacDeployer = new AccessControlledDeployer(admin, pauser, unpauser);
 
@@ -38,17 +42,17 @@ contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
      * Constructor
      */
     function test_Constructor_RevertIf_AdminIsZeroAddress() public {
-        vm.expectRevert("admin is the zero address");
+        vm.expectRevert(ZeroAddress.selector);
         new AccessControlledDeployer(address(0), pauser, unpauser);
     }
 
     function test_Constructor_RevertIf_PauserIsZeroAddress() public {
-        vm.expectRevert("pauser is the zero address");
+        vm.expectRevert(ZeroAddress.selector);
         new AccessControlledDeployer(admin, address(0), unpauser);
     }
 
     function test_Constructor_RevertIf_UnpauserIsZeroAddress() public {
-        vm.expectRevert("unpauser is the zero address");
+        vm.expectRevert(ZeroAddress.selector);
         new AccessControlledDeployer(admin, pauser, address(0));
     }
 
@@ -91,20 +95,20 @@ contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
     function test_RevertIf_TransferDeployerOwnership_WithZeroOwnerAddress() public {
         OwnableCreate2Deployer create2Deployer = new OwnableCreate2Deployer(address(rbacDeployer));
         vm.startPrank(admin);
-        vm.expectRevert("new owner is the zero address");
+        vm.expectRevert(ZeroAddress.selector);
         rbacDeployer.transferOwnershipOfDeployer(create2Deployer, address(0));
     }
 
     function test_RevertIf_TransferDeployerOwnership_WhenNotCurrentOwner() public {
         OwnableCreate2Deployer create2Deployer = new OwnableCreate2Deployer(makeAddr("currentOwner"));
         vm.startPrank(admin);
-        vm.expectRevert("deployer contract is not owned by this contract");
+        vm.expectRevert(NotOwnerOfDeployer.selector);
         rbacDeployer.transferOwnershipOfDeployer(create2Deployer, makeAddr("newOwner2"));
     }
 
     function test_RevertIf_TransferDeployerOwnership_WithZeroDeployerAddress() public {
         vm.startPrank(admin);
-        vm.expectRevert("deployer contract is the zero address");
+        vm.expectRevert(ZeroAddress.selector);
         rbacDeployer.transferOwnershipOfDeployer(Ownable(address(0)), makeAddr("newOwner2"));
     }
 
@@ -169,7 +173,7 @@ contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
      */
     function test_RevertIf_GrantDeployerRole_WithEmptyArray() public {
         address[] memory emptyDeployers = new address[](0);
-        vm.expectRevert("deployers list is empty");
+        vm.expectRevert(EmptyDeployerList.selector);
         vm.prank(admin);
         rbacDeployer.grantDeployerRole(emptyDeployers);
     }
@@ -180,7 +184,7 @@ contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
         // note that second deployer in the array is the zero address
 
         vm.prank(admin);
-        vm.expectRevert("deployer is the zero address");
+        vm.expectRevert(ZeroAddress.selector);
         rbacDeployer.grantDeployerRole(newDeployers);
     }
 
@@ -213,7 +217,7 @@ contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
 
     function test_RevertIf_RevokeDeployerRole_WithEmptyArray() public {
         address[] memory emptyDeployers = new address[](0);
-        vm.expectRevert("deployers list is empty");
+        vm.expectRevert(EmptyDeployerList.selector);
         vm.prank(admin);
         rbacDeployer.revokeDeployerRole(emptyDeployers);
     }
@@ -224,7 +228,7 @@ contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
         // note that second deployer in the array is the zero address
 
         vm.prank(admin);
-        vm.expectRevert("deployer is the zero address");
+        vm.expectRevert(ZeroAddress.selector);
         rbacDeployer.grantDeployerRole(existingDeployers);
     }
 

--- a/test/deployer/AccessControlledDeployer.t.sol
+++ b/test/deployer/AccessControlledDeployer.t.sol
@@ -130,7 +130,7 @@ contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
 
     function test_TransferDeployerOwnership_ForOwnableCreate3Deployer() public {
         OwnableCreate3Deployer create3Deployer = new OwnableCreate3Deployer(address(rbacDeployer));
-        assertTrue(create2Deployer.owner() == address(rbacDeployer));
+        assertTrue(create3Deployer.owner() == address(rbacDeployer));
 
         address newOwner = makeAddr("newOwner");
         vm.startPrank(admin);

--- a/test/deployer/AccessControlledDeployer.t.sol
+++ b/test/deployer/AccessControlledDeployer.t.sol
@@ -1,0 +1,368 @@
+// Copyright Immutable Pty Ltd 2018 - 2024
+// SPDX-License-Identifier: Apache 2.0
+pragma solidity 0.8.19;
+
+import "forge-std/Test.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IDeployer} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IDeployer.sol";
+import {ERC20MintableBurnable} from
+    "@axelar-network/axelar-gmp-sdk-solidity/contracts/test/token/ERC20MintableBurnable.sol";
+import {ERC20MintableBurnableInit} from
+    "@axelar-network/axelar-gmp-sdk-solidity/contracts/test/token/ERC20MintableBurnableInit.sol";
+
+import {OwnableCreate2Deployer} from "../../contracts/deployer/create2/OwnableCreate2Deployer.sol";
+import {AccessControlledDeployer} from "../../contracts/deployer/AccessControlledDeployer.sol";
+import {OwnableCreate3Deployer} from "../../contracts/deployer/create3/OwnableCreate3Deployer.sol";
+
+import {Create2Utils} from "./create2/Create2Utils.sol";
+import {Create3Utils} from "./create3/Create3Utils.sol";
+
+contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
+    address private admin = makeAddr("admin");
+    address private pauser = makeAddr("pauser");
+    address private unpauser = makeAddr("unpauser");
+    address[] private authDeployers;
+    AccessControlledDeployer private rbacDeployer;
+
+    event Deployed(address indexed deployedAddress, address indexed sender, bytes32 indexed salt, bytes32 bytecodeHash);
+
+    function setUp() public {
+        rbacDeployer = new AccessControlledDeployer(admin, pauser, unpauser);
+
+        authDeployers.push(makeAddr("deployer1"));
+        vm.prank(admin);
+        rbacDeployer.grantDeployerRole(authDeployers);
+    }
+
+    /**
+     * Constructor
+     */
+    function test_Constructor_RevertIf_AdminIsZeroAddress() public {
+        vm.expectRevert("admin is the zero address");
+        new AccessControlledDeployer(address(0), pauser, unpauser);
+    }
+
+    function test_Constructor_RevertIf_PauserIsZeroAddress() public {
+        vm.expectRevert("pauser is the zero address");
+        new AccessControlledDeployer(admin, address(0), unpauser);
+    }
+
+    function test_Constructor_RevertIf_UnpauserIsZeroAddress() public {
+        vm.expectRevert("unpauser is the zero address");
+        new AccessControlledDeployer(admin, pauser, address(0));
+    }
+
+    function test_Constructor_AssignsRoles() public {
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.DEFAULT_ADMIN_ROLE(), admin));
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.PAUSER_ROLE(), pauser));
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.UNPAUSER_ROLE(), unpauser));
+    }
+
+    /**
+     * Admin role management
+     */
+    function test_AdminCanAssignRoles() public {
+        address newPauser = makeAddr("newPauser");
+        address newUnpauser = makeAddr("newUnpauser");
+
+        vm.startPrank(admin);
+        rbacDeployer.grantRole(rbacDeployer.PAUSER_ROLE(), newPauser);
+        rbacDeployer.grantRole(rbacDeployer.UNPAUSER_ROLE(), newUnpauser);
+
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.PAUSER_ROLE(), newPauser));
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.UNPAUSER_ROLE(), newUnpauser));
+    }
+
+    function test_AdminCanRevokeRoles() public {
+        vm.startPrank(admin);
+        rbacDeployer.revokeRole(rbacDeployer.PAUSER_ROLE(), pauser);
+        rbacDeployer.revokeRole(rbacDeployer.UNPAUSER_ROLE(), unpauser);
+
+        assertFalse(rbacDeployer.hasRole(rbacDeployer.PAUSER_ROLE(), pauser));
+        assertFalse(rbacDeployer.hasRole(rbacDeployer.UNPAUSER_ROLE(), unpauser));
+    }
+
+    function test_RevertIf_TransferDeployerOwnership_ByNonAdmin() public {
+        OwnableCreate2Deployer create2Deployer = new OwnableCreate2Deployer(address(rbacDeployer));
+        vm.expectRevert();
+        rbacDeployer.transferOwnershipOfDeployer(create2Deployer, makeAddr("newOwner2"));
+    }
+
+    function test_RevertIf_TransferDeployerOwnership_WithZeroOwnerAddress() public {
+        OwnableCreate2Deployer create2Deployer = new OwnableCreate2Deployer(address(rbacDeployer));
+        vm.startPrank(admin);
+        vm.expectRevert("new owner is the zero address");
+        rbacDeployer.transferOwnershipOfDeployer(create2Deployer, address(0));
+    }
+
+    function test_RevertIf_TransferDeployerOwnership_WhenNotCurrentOwner() public {
+        OwnableCreate2Deployer create2Deployer = new OwnableCreate2Deployer(makeAddr("currentOwner"));
+        vm.startPrank(admin);
+        vm.expectRevert("deployer contract is not owned by this contract");
+        rbacDeployer.transferOwnershipOfDeployer(create2Deployer, makeAddr("newOwner2"));
+    }
+
+    function test_RevertIf_TransferDeployerOwnership_WithZeroDeployerAddress() public {
+        vm.startPrank(admin);
+        vm.expectRevert("deployer contract is the zero address");
+        rbacDeployer.transferOwnershipOfDeployer(Ownable(address(0)), makeAddr("newOwner2"));
+    }
+
+    function test_TransferDeployerOwnership_ForOwnableCreate2Deployer() public {
+        OwnableCreate2Deployer create2Deployer = new OwnableCreate2Deployer(address(rbacDeployer));
+        address newOwner = makeAddr("newOwner");
+        vm.startPrank(admin);
+        rbacDeployer.transferOwnershipOfDeployer(create2Deployer, newOwner);
+        assertTrue(create2Deployer.owner() == newOwner);
+    }
+
+    function test_TransferDeployerOwnership_ForOwnableCreate3Deployer() public {
+        OwnableCreate3Deployer create3Deployer = new OwnableCreate3Deployer(address(rbacDeployer));
+        address newOwner = makeAddr("newOwner");
+        vm.startPrank(admin);
+        rbacDeployer.transferOwnershipOfDeployer(create3Deployer, newOwner);
+        assertTrue(create3Deployer.owner() == newOwner);
+    }
+
+    /**
+     * Pauser and Unpauser role management
+     */
+    function test_OnlyPauserRoleCanPause() public {
+        // check random user can't pause
+        vm.expectRevert();
+        rbacDeployer.pause();
+
+        // check admin can't pause
+        vm.prank(admin);
+        vm.expectRevert();
+        rbacDeployer.pause();
+
+        // check address with pauser role can pause
+        vm.startPrank(pauser);
+        rbacDeployer.pause();
+        assertTrue(rbacDeployer.paused());
+    }
+
+    function test_OnlyUnpauserRoleCanUnpause() public {
+        // pause first
+        vm.prank(pauser);
+        rbacDeployer.pause();
+        assertTrue(rbacDeployer.paused());
+
+        // check random address can't unpause
+        vm.expectRevert();
+        rbacDeployer.pause();
+
+        // check admin can't unpause
+        vm.prank(admin);
+        vm.expectRevert();
+        rbacDeployer.pause();
+
+        // check unpauser role can unpause
+        vm.startPrank(unpauser);
+        rbacDeployer.unpause();
+        assertFalse(rbacDeployer.paused());
+    }
+
+    /**
+     * Deployer role management
+     */
+    function test_RevertIf_GrantDeployerRole_WithEmptyArray() public {
+        address[] memory emptyDeployers = new address[](0);
+        vm.expectRevert("deployers list is empty");
+        vm.prank(admin);
+        rbacDeployer.grantDeployerRole(emptyDeployers);
+    }
+
+    function test_RevertIf_GrantDeployerRole_ContainsZeroAddress() public {
+        address[] memory newDeployers = new address[](2);
+        newDeployers[0] = makeAddr("deployer2");
+        // note that second deployer in the array is the zero address
+
+        vm.prank(admin);
+        vm.expectRevert("deployer is the zero address");
+        rbacDeployer.grantDeployerRole(newDeployers);
+    }
+
+    function test_GrantDeployerRole_WithOneDeployer() public {
+        address[] memory newDeployers = new address[](1);
+        newDeployers[0] = makeAddr("deployer2");
+
+        assertFalse(rbacDeployer.hasRole(rbacDeployer.DEPLOYER_ROLE(), newDeployers[0]));
+
+        vm.prank(admin);
+        rbacDeployer.grantDeployerRole(newDeployers);
+
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.DEPLOYER_ROLE(), newDeployers[0]));
+    }
+
+    function test_GrantDeployerRole_WithMultipleDeployers() public {
+        address[] memory newDeployers = new address[](2);
+        newDeployers[0] = makeAddr("deployer2");
+        newDeployers[1] = makeAddr("deployer3");
+
+        assertFalse(rbacDeployer.hasRole(rbacDeployer.DEPLOYER_ROLE(), newDeployers[0]));
+        assertFalse(rbacDeployer.hasRole(rbacDeployer.DEPLOYER_ROLE(), newDeployers[1]));
+
+        vm.prank(admin);
+        rbacDeployer.grantDeployerRole(newDeployers);
+
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.DEPLOYER_ROLE(), newDeployers[0]));
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.DEPLOYER_ROLE(), newDeployers[1]));
+    }
+
+    function test_RevertIf_RevokeDeployerRole_WithEmptyArray() public {
+        address[] memory emptyDeployers = new address[](0);
+        vm.expectRevert("deployers list is empty");
+        vm.prank(admin);
+        rbacDeployer.revokeDeployerRole(emptyDeployers);
+    }
+
+    function test_RevertIf_RevokeDeployerRole_ContainsZeroAddress() public {
+        address[] memory existingDeployers = new address[](2);
+        existingDeployers[0] = makeAddr("deployer1");
+        // note that second deployer in the array is the zero address
+
+        vm.prank(admin);
+        vm.expectRevert("deployer is the zero address");
+        rbacDeployer.grantDeployerRole(existingDeployers);
+    }
+
+    function test_RevokeDeployerRole_GivenOneDeployer() public {
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.DEPLOYER_ROLE(), authDeployers[0]));
+
+        vm.prank(admin);
+        rbacDeployer.revokeDeployerRole(authDeployers);
+
+        assertFalse(rbacDeployer.hasRole(rbacDeployer.DEPLOYER_ROLE(), authDeployers[0]));
+    }
+
+    function test_RevokeDeployerRole_GivenMultipleDeployers() public {
+        address[] memory newDeployers = new address[](2);
+        newDeployers[0] = makeAddr("deployer2");
+        newDeployers[1] = makeAddr("deployer3");
+
+        vm.prank(admin);
+        rbacDeployer.grantDeployerRole(newDeployers);
+
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.DEPLOYER_ROLE(), newDeployers[0]));
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.DEPLOYER_ROLE(), newDeployers[1]));
+
+        vm.prank(admin);
+        rbacDeployer.revokeDeployerRole(newDeployers);
+
+        assertFalse(rbacDeployer.hasRole(rbacDeployer.DEPLOYER_ROLE(), newDeployers[0]));
+        assertFalse(rbacDeployer.hasRole(rbacDeployer.DEPLOYER_ROLE(), newDeployers[1]));
+    }
+
+    /**
+     * Contract Deployment
+     */
+    function test_RevertIf_Deploy_WithUnauthorizedAddress() public {
+        vm.expectRevert();
+        rbacDeployer.deploy(IDeployer(address(0)), new bytes(0), bytes32(0));
+    }
+
+    function test_Deploy_UsingCreate2() public {
+        OwnableCreate2Deployer create2Deployer = new OwnableCreate2Deployer(address(rbacDeployer));
+        bytes memory erc20MintableBytecode =
+            abi.encodePacked(type(ERC20MintableBurnable).creationCode, abi.encode("Test Token", "TEST", 10));
+        bytes32 erc20MintableSalt = createSaltFromKey("erc20-mintable-burnable-v1", address(rbacDeployer));
+
+        address expectedAddress = predictCreate2Address(
+            erc20MintableBytecode, address(create2Deployer), address(rbacDeployer), erc20MintableSalt
+        );
+
+        vm.startPrank(authDeployers[0]);
+        vm.expectEmit();
+        emit Deployed(expectedAddress, address(rbacDeployer), erc20MintableSalt, keccak256(erc20MintableBytecode));
+        address deployedAddress = rbacDeployer.deploy(create2Deployer, erc20MintableBytecode, erc20MintableSalt);
+        ERC20MintableBurnable deployed = ERC20MintableBurnable(deployedAddress);
+
+        assertEq(deployedAddress, expectedAddress, "deployed address does not match expected");
+        assertEq(deployed.name(), "Test Token", "deployed contract does not match expected");
+        assertEq(deployed.symbol(), "TEST", "deployed contract does not match expected");
+        assertEq(deployed.decimals(), 10, "deployed contract does not match expected");
+    }
+
+    function test_DeployAndInit_UsingCreate2() public {
+        OwnableCreate2Deployer create2Deployer = new OwnableCreate2Deployer(address(rbacDeployer));
+        bytes memory mintableInitBytecode =
+            abi.encodePacked(type(ERC20MintableBurnableInit).creationCode, abi.encode(10));
+
+        bytes32 mintableInitSalt = createSaltFromKey("erc20-mintable-burnable-init-v1", address(rbacDeployer));
+
+        address expectedAddress = predictCreate2Address(
+            mintableInitBytecode, address(create2Deployer), address(rbacDeployer), mintableInitSalt
+        );
+
+        bytes memory initPayload = abi.encodeWithSelector(ERC20MintableBurnableInit.init.selector, "Test Token", "TEST");
+        vm.startPrank(authDeployers[0]);
+        vm.expectEmit();
+        emit Deployed(expectedAddress, address(rbacDeployer), mintableInitSalt, keccak256(mintableInitBytecode));
+        address deployedAddress =
+            rbacDeployer.deployAndInit(create2Deployer, mintableInitBytecode, mintableInitSalt, initPayload);
+        ERC20MintableBurnableInit deployed = ERC20MintableBurnableInit(deployedAddress);
+
+        assertEq(deployedAddress, expectedAddress, "deployed address does not match expected");
+        assertEq(deployed.name(), "Test Token", "deployed contract does not match expected");
+        assertEq(deployed.symbol(), "TEST", "deployed contract does not match expected");
+        assertEq(deployed.decimals(), 10, "deployed contract does not match expected");
+    }
+
+    function test_Deploy_UsingCreate3() public {
+        OwnableCreate3Deployer create3Deployer = new OwnableCreate3Deployer(address(rbacDeployer));
+        bytes memory erc20MintableBytecode =
+            abi.encodePacked(type(ERC20MintableBurnable).creationCode, abi.encode("Test Token", "TEST", 10));
+        bytes32 erc20MintableSalt = createSaltFromKey("erc20-mintable-burnable-v1", address(rbacDeployer));
+
+        address expectedAddress = predictCreate3Address(create3Deployer, address(rbacDeployer), erc20MintableSalt);
+
+        vm.startPrank(authDeployers[0]);
+        vm.expectEmit();
+        emit Deployed(expectedAddress, address(rbacDeployer), erc20MintableSalt, keccak256(erc20MintableBytecode));
+        address deployedAddress = rbacDeployer.deploy(create3Deployer, erc20MintableBytecode, erc20MintableSalt);
+        ERC20MintableBurnable deployed = ERC20MintableBurnable(deployedAddress);
+
+        assertEq(deployedAddress, expectedAddress, "deployed address does not match expected");
+        assertEq(deployed.name(), "Test Token", "deployed contract does not match expected");
+        assertEq(deployed.symbol(), "TEST", "deployed contract does not match expected");
+        assertEq(deployed.decimals(), 10, "deployed contract does not match expected");
+    }
+
+    function test_DeployAndInit_UsingCreate3() public {
+        OwnableCreate3Deployer create3Deployer = new OwnableCreate3Deployer(address(rbacDeployer));
+        bytes memory erc20MintableInitBytcode =
+            abi.encodePacked(type(ERC20MintableBurnableInit).creationCode, abi.encode(10));
+
+        bytes32 erc20MintableSalt = createSaltFromKey("erc20-mintable-burnable-init-v1", address(rbacDeployer));
+
+        address expectedAddress = predictCreate3Address(create3Deployer, address(rbacDeployer), erc20MintableSalt);
+
+        vm.startPrank(authDeployers[0]);
+        bytes memory initPayload = abi.encodeWithSelector(ERC20MintableBurnableInit.init.selector, "Test Token", "TEST");
+        vm.expectEmit();
+        emit Deployed(expectedAddress, address(rbacDeployer), erc20MintableSalt, keccak256(erc20MintableInitBytcode));
+        address deployedAddress =
+            rbacDeployer.deployAndInit(create3Deployer, erc20MintableInitBytcode, erc20MintableSalt, initPayload);
+        ERC20MintableBurnableInit deployed = ERC20MintableBurnableInit(deployedAddress);
+
+        assertEq(deployedAddress, expectedAddress, "deployed address does not match expected");
+        assertEq(deployed.name(), "Test Token", "deployed contract does not match expected");
+        assertEq(deployed.symbol(), "TEST", "deployed contract does not match expected");
+        assertEq(deployed.decimals(), 10, "deployed contract does not match expected");
+    }
+
+    function test_DeployFails_WhenPaused() public {
+        vm.startPrank(pauser);
+
+        rbacDeployer.pause();
+        assertTrue(rbacDeployer.paused());
+
+        vm.expectRevert("Pausable: paused");
+        rbacDeployer.deploy(IDeployer(address(0)), new bytes(0), bytes32(0));
+
+        vm.expectRevert("Pausable: paused");
+        rbacDeployer.deployAndInit(IDeployer(address(0)), new bytes(0), bytes32(0), new bytes(0));
+    }
+}

--- a/test/deployer/AccessControlledDeployer.t.sol
+++ b/test/deployer/AccessControlledDeployer.t.sol
@@ -69,6 +69,9 @@ contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
         address newPauser = makeAddr("newPauser");
         address newUnpauser = makeAddr("newUnpauser");
 
+        assertFalse(rbacDeployer.hasRole(rbacDeployer.PAUSER_ROLE(), newPauser));
+        assertFalse(rbacDeployer.hasRole(rbacDeployer.UNPAUSER_ROLE(), newUnpauser));
+
         vm.startPrank(admin);
         rbacDeployer.grantRole(rbacDeployer.PAUSER_ROLE(), newPauser);
         rbacDeployer.grantRole(rbacDeployer.UNPAUSER_ROLE(), newUnpauser);
@@ -79,6 +82,9 @@ contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
 
     function test_AdminCanRevokeRoles() public {
         vm.startPrank(admin);
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.PAUSER_ROLE(), pauser));
+        assertTrue(rbacDeployer.hasRole(rbacDeployer.UNPAUSER_ROLE(), unpauser));
+
         rbacDeployer.revokeRole(rbacDeployer.PAUSER_ROLE(), pauser);
         rbacDeployer.revokeRole(rbacDeployer.UNPAUSER_ROLE(), unpauser);
 
@@ -114,6 +120,8 @@ contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
 
     function test_TransferDeployerOwnership_ForOwnableCreate2Deployer() public {
         OwnableCreate2Deployer create2Deployer = new OwnableCreate2Deployer(address(rbacDeployer));
+        assertTrue(create2Deployer.owner() == address(rbacDeployer));
+
         address newOwner = makeAddr("newOwner");
         vm.startPrank(admin);
         rbacDeployer.transferOwnershipOfDeployer(create2Deployer, newOwner);
@@ -122,6 +130,8 @@ contract AccessControlledDeployerTest is Test, Create2Utils, Create3Utils {
 
     function test_TransferDeployerOwnership_ForOwnableCreate3Deployer() public {
         OwnableCreate3Deployer create3Deployer = new OwnableCreate3Deployer(address(rbacDeployer));
+        assertTrue(create2Deployer.owner() == address(rbacDeployer));
+
         address newOwner = makeAddr("newOwner");
         vm.startPrank(admin);
         rbacDeployer.transferOwnershipOfDeployer(create3Deployer, newOwner);

--- a/test/deployer/create2/Create2Utils.sol
+++ b/test/deployer/create2/Create2Utils.sol
@@ -1,0 +1,22 @@
+// Copyright Immutable Pty Ltd 2018 - 2023
+// SPDX-License-Identifier: Apache 2.0
+pragma solidity 0.8.19;
+
+import "forge-std/Test.sol";
+
+contract Create2Utils is Test {
+    function predictCreate2Address(bytes memory _bytecode, address _deployer, address _sender, bytes32 _salt)
+        public
+        pure
+        returns (address)
+    {
+        bytes32 deploySalt = keccak256(abi.encode(_sender, _salt));
+        return address(
+            uint160(uint256(keccak256(abi.encodePacked(hex"ff", address(_deployer), deploySalt, keccak256(_bytecode)))))
+        );
+    }
+
+    function createSaltFromKey(string memory key, address owner) public pure returns (bytes32) {
+        return keccak256(abi.encode(address(owner), key));
+    }
+}

--- a/test/deployer/create3/Create3Utils.sol
+++ b/test/deployer/create3/Create3Utils.sol
@@ -1,0 +1,12 @@
+// Copyright Immutable Pty Ltd 2018 - 2023
+// SPDX-License-Identifier: Apache 2.0
+pragma solidity 0.8.19;
+
+import "forge-std/Test.sol";
+import {IDeployer} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IDeployer.sol";
+
+contract Create3Utils is Test {
+    function predictCreate3Address(IDeployer _deployer, address _sender, bytes32 _salt) public view returns (address) {
+        return _deployer.deployedAddress("", _sender, _salt);
+    }
+}

--- a/test/deployer/create3/OwnableCreate3Deployer.t.sol
+++ b/test/deployer/create3/OwnableCreate3Deployer.t.sol
@@ -3,16 +3,20 @@
 pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
-import {ERC20Mock} from "@openzeppelin/contracts/mocks/ERC20Mock.sol";
 import {IDeploy} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IDeploy.sol";
-import {ERC20MintableBurnable} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/test/token/ERC20MintableBurnable.sol";
-import {ERC20MintableBurnableInit} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/test/token/ERC20MintableBurnableInit.sol";
+
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/ERC20Mock.sol";
+import {ERC20MintableBurnable} from
+    "@axelar-network/axelar-gmp-sdk-solidity/contracts/test/token/ERC20MintableBurnable.sol";
+import {ERC20MintableBurnableInit} from
+    "@axelar-network/axelar-gmp-sdk-solidity/contracts/test/token/ERC20MintableBurnableInit.sol";
 import {ContractAddress} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/libs/ContractAddress.sol";
 
 import {OwnableCreate3Deployer} from "../../../contracts/deployer/create3/OwnableCreate3Deployer.sol";
 import {OwnableCreateDeploy} from "../../../contracts/deployer/create/OwnableCreateDeploy.sol";
+import {Create3Utils} from "./Create3Utils.sol";
 
-contract OwnableCreate3DeployerTest is Test {
+contract OwnableCreate3DeployerTest is Test, Create3Utils {
     OwnableCreate3Deployer private factory;
     bytes private erc20MockBytecode;
     bytes32 private erc20MockSalt;
@@ -58,7 +62,7 @@ contract OwnableCreate3DeployerTest is Test {
 
     /// @dev ensure contracts are deployed at the expected address
     function test_deploy_DeploysContractAtExpectedAddress() public {
-        address expectedAddress = _predictCreate3Address(address(factoryOwner), erc20MockSalt);
+        address expectedAddress = predictCreate3Address(factory, address(factoryOwner), erc20MockSalt);
 
         /// forward the nonce of the owner and the factory, to confirm they doesn't influence address
         vm.setNonce(factoryOwner, vm.getNonce(factoryOwner) + 10);
@@ -77,7 +81,7 @@ contract OwnableCreate3DeployerTest is Test {
             abi.encodePacked(type(ERC20MintableBurnable).creationCode, abi.encode("Test Token", "TEST", 18));
         bytes32 erc20MintableSalt = _createSaltFromKey("erc20-mintable-burnable-v1");
 
-        address expectedAddress = _predictCreate3Address(address(factoryOwner), erc20MintableSalt);
+        address expectedAddress = predictCreate3Address(factory, address(factoryOwner), erc20MintableSalt);
 
         vm.expectEmit();
         emit Deployed(expectedAddress, address(factoryOwner), erc20MintableSalt, keccak256(erc20MintableBytecode));
@@ -112,7 +116,7 @@ contract OwnableCreate3DeployerTest is Test {
 
         // test that the new owner can deploy
         vm.startPrank(newOwner);
-        address expectedAddress = _predictCreate3Address(address(newOwner), erc20MockSalt);
+        address expectedAddress = predictCreate3Address(factory, address(newOwner), erc20MockSalt);
 
         vm.expectEmit();
         emit Deployed(expectedAddress, address(newOwner), erc20MockSalt, keccak256(erc20MockBytecode));
@@ -161,7 +165,7 @@ contract OwnableCreate3DeployerTest is Test {
 
         bytes32 mintableInitSalt = _createSaltFromKey("erc20-mintable-burnable-init-v1");
 
-        address expectedAddress = _predictCreate3Address(address(factoryOwner), mintableInitSalt);
+        address expectedAddress = predictCreate3Address(factory, address(factoryOwner), mintableInitSalt);
 
         bytes memory initPayload = abi.encodeWithSelector(ERC20MintableBurnableInit.init.selector, "Test Token", "TEST");
         vm.expectEmit();
@@ -234,10 +238,6 @@ contract OwnableCreate3DeployerTest is Test {
     /**
      * private helper functions
      */
-    function _predictCreate3Address(address _sender, bytes32 _salt) private view returns (address) {
-        return factory.deployedAddress("", _sender, _salt);
-    }
-
     function _createSaltFromKey(string memory key) private view returns (bytes32) {
         return keccak256(abi.encode(address(factoryOwner), key));
     }


### PR DESCRIPTION
The existing `OwnableCreate2Deployer` and `OwnableCreate3Deployer` contracts only allow a single deployer address—the owner—to deploy contracts. There is a need to enhance this so as to allow a set of authorised addresses to deploy contracts. This PR introduces a new contract that forwards deployment requests to the existing Create2 and Create3 deployers while layering role-based access controls to these capabilities. This contract could thus enable more flexible deployment access controls for existing single-owner Create2 and Create3 deployers.
Additional details of this requirement can be found [here](https://immutable.atlassian.net/wiki/spaces/~71202063c6a3620e6b4ab4a8bc3dd0bdfc3297/pages/2504949857/Breaking+up+the+Deployment+Key).