### PR TITLE
[TD-1549] Update installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ These contracts are feature-rich and are the recommended standard on Immutable z
 ### Installation
 
 ```
-$ yarn install @imtbl/contracts
+$ yarn add @imtbl/contracts
 ```
 
 ### Usage


### PR DESCRIPTION
Fixes `yarn` installation command as `yarn install [PACKAGE]` is no longer available.