### PR TITLE
Update GuardedMulticaller2 Multicall Typehash

### DIFF
--- a/abi/generated.ts
+++ b/abi/generated.ts
@@ -618,6 +618,7 @@ export const guardedMulticaller2Abi = [
           { name: 'data', internalType: 'bytes', type: 'bytes' },
         ],
       },
+      { name: '_returnData', internalType: 'bytes', type: 'bytes' },
     ],
     name: 'FailedCall',
   },

--- a/contracts/multicall/GuardedMulticaller2.sol
+++ b/contracts/multicall/GuardedMulticaller2.sol
@@ -43,7 +43,7 @@ contract GuardedMulticaller2 is AccessControl, ReentrancyGuard, EIP712 {
     /// @dev EIP712 typehash for execute function
     bytes32 internal constant MULTICALL_TYPEHASH =
         keccak256(
-            "Multicall(bytes32 ref,Call[] call,uint256 deadline)Call(address target,string functionSignature,bytes data)"
+            "Multicall(bytes32 ref,Call[] calls,uint256 deadline)Call(address target,string functionSignature,bytes data)"
         );
 
     /// @dev Event emitted when execute function is called

--- a/test/multicall/SigUtils.t.sol
+++ b/test/multicall/SigUtils.t.sol
@@ -11,7 +11,7 @@ contract SigUtils {
 
     bytes32 internal constant MULTICALL_TYPEHASH =
         keccak256(
-            "Multicall(bytes32 ref,Call[] call,uint256 deadline)Call(address target,string functionSignature,bytes data)"
+            "Multicall(bytes32 ref,Call[] calls,uint256 deadline)Call(address target,string functionSignature,bytes data)"
         );
 
     bytes32 private immutable cachedDomainSeparator;


### PR DESCRIPTION
There is a typo in `MULTICALL_TYPEHASH` that we should fix. This does not affect the behavior of the contract. It would, however, affect how the signature should be generated off-chain. Considering no one has used the contract, we would prefer to fix this issue.