### PR TITLE
[ITSEC-2280] Add Dependency Review and SBOM signing jobs, update CODEOWNERS

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,8 @@ jobs:
   publish:
     name: Publish to NPM
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -58,6 +60,11 @@ jobs:
         run: |
           rm -rf dist && yarn build
 
+      - name: Generate SDK attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: './dist'
+  
       - name: Publish package
         uses: JS-DevTools/npm-publish@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,16 @@ jobs:
         uses: actions/checkout@v3
       - name: Run check script
         run: sh readmecheck.sh
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Checkout Repository'
+      uses: actions/checkout@v4
+    - name: Dependency Review
+      uses: actions/dependency-review-action@v4
+      with:
+        # Possible values: "critical", "high", "moderate", "low"
+        fail-on-severity: critical
   publish:
     name: Publish to NPM (dry run)
     runs-on: ubuntu-latest

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
+.github @immutable/assets @immutable/traders @immutable/prodsec
+
 /clients @immutable/assets
 /abi @immutable/assets
 


### PR DESCRIPTION
1. Adds [SBOM artifact signing](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) job as we publish to NPM.
2. Adds [Dependency Review](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review) job that fails on Critical severity findings (Node/JavaScript)
3. Adds Product Security to CODEOWNERS under .github along with the current maintainers (for visibility to job changes)