### PR TITLE
Add a security warning

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,8 +10,8 @@ jobs:
     name: Publish to NPM
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # Required for GitHub Attestation
-      attestations: write # Required for GitHub Attestation 
+      id-token: write # ! Required for GitHub Attestations, removing will create a Sev 0 incident !
+      attestations: write # ! Required for GitHub Attestations, removing will create a Sev 0 incident !
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -61,6 +61,7 @@ jobs:
         run: |
           rm -rf dist && yarn build
 
+      # ! Do NOT remove - this will cause a Sev 0 incident !
       - name: Generate SDK attestation
         uses: actions/attest-build-provenance@v1
         with:


### PR DESCRIPTION
Similar to https://github.com/immutable/ts-immutable-sdk/pull/2356, adds a note as to the critical code section

> Removing or preventing GitHub from attesting the code will cause a critical security incident - clarify in the comments.
