### PR TITLE
Fix: Corrected @param typos in NatSpec comments

### DIFF
--- a/contracts/access/MintingAccessControl.sol
+++ b/contracts/access/MintingAccessControl.sol
@@ -10,7 +10,7 @@ abstract contract MintingAccessControl is AccessControlEnumerable {
 
     /**
      * @notice Allows admin grant `user` `MINTER` role
-     *  @param user The address to grant the `MINTER` role to
+     * @param user The address to grant the `MINTER` role to
      */
     function grantMinterRole(address user) public onlyRole(DEFAULT_ADMIN_ROLE) {
         grantRole(MINTER_ROLE, user);
@@ -18,7 +18,7 @@ abstract contract MintingAccessControl is AccessControlEnumerable {
 
     /**
      * @notice Allows admin to revoke `MINTER_ROLE` role from `user`
-     *  @param user The address to revoke the `MINTER` role from
+     * @param user The address to revoke the `MINTER` role from
      */
     function revokeMinterRole(address user) public onlyRole(DEFAULT_ADMIN_ROLE) {
         revokeRole(MINTER_ROLE, user);


### PR DESCRIPTION
This is a small fix to remove white space preceding a couple of `@param` tags in the `MintingAccessControl.sol` abstract contract.

NatSpec documentation tools (like those used to generate documentation websites from Solidity code) rely on correctly formatted tags like `@param`, `@return`, `@notice`, etc. The non-breaking space may prevent these tools from correctly parsing the comment, which means the parameter documentation might not be displayed correctly in generated documentation.