### PR TITLE
Fix: Potential transfer bypass vulnerability

### DIFF
--- a/contracts/allowlist/OperatorAllowlistEnforced.sol
+++ b/contracts/allowlist/OperatorAllowlistEnforced.sol
@@ -61,8 +61,9 @@ abstract contract OperatorAllowlistEnforced is OperatorAllowlistEnforcementError
      */
     modifier validateTransfer(address from, address to) {
         // Check for:
-        // 1. caller is an EOA
-        // 2. caller is Allowlisted or the calling address bytecode is Allowlisted
+        // 1. caller address is different from the transaction origin address
+        // 2. caller is an EOA
+        // 3. caller is Allowlisted or the calling address bytecode is Allowlisted
         if (
             msg.sender != tx.origin && // solhint-disable-line avoid-tx-origin
             msg.sender.code.length != 0 &&

--- a/contracts/allowlist/OperatorAllowlistEnforced.sol
+++ b/contracts/allowlist/OperatorAllowlistEnforced.sol
@@ -62,9 +62,10 @@ abstract contract OperatorAllowlistEnforced is OperatorAllowlistEnforcementError
     modifier validateTransfer(address from, address to) {
         // Check for:
         // 1. caller is an EOA
-        // 2. caller is Allowlisted or is the calling address bytecode is Allowlisted
+        // 2. caller is Allowlisted or the calling address bytecode is Allowlisted
         if (
             msg.sender != tx.origin && // solhint-disable-line avoid-tx-origin
+            msg.sender.code.length != 0 &&
             !operatorAllowlist.isAllowlisted(msg.sender)
         ) {
             revert CallerNotInAllowlist(msg.sender);


### PR DESCRIPTION
The current `validateTransfer` check appears to have a subtle flaw; it only checks if `msg.sender` is different from `tx.origin`. It doesn't check if `msg.sender` is a contract.

A malicious EOA could potentially create a contract that simply calls the transfer function. Because `msg.sender` (the malicious contract's address) would be different from `tx.origin` (the malicious EOA's address), the allowlist check for `msg.sender` would be bypassed. This means the malicious EOA could effectively transfer tokens even if their contract (and therefore indirectly, themselves) is not on the allowlist.

The modifier should explicitly check if `msg.sender` is an EOA before skipping the allowlist check.