### PR TITLE
Fix: Potential Overflow in _totalSupply

### DIFF
--- a/contracts/token/erc721/abstract/ImmutableERC721Base.sol
+++ b/contracts/token/erc721/abstract/ImmutableERC721Base.sol
@@ -241,7 +241,7 @@ abstract contract ImmutableERC721Base is OperatorAllowlistEnforced, MintingAcces
         }
 
         // slither-disable-next-line costly-loop
-        _totalSupply = _totalSupply + mintRequest.tokenIds.length;
+        _totalSupply += mintRequest.tokenIds.length;
         for (uint256 j = 0; j < mintRequest.tokenIds.length; j++) {
             _mint(mintRequest.to, mintRequest.tokenIds[j]);
         }
@@ -260,7 +260,7 @@ abstract contract ImmutableERC721Base is OperatorAllowlistEnforced, MintingAcces
             _safeMint(mintRequest.to, mintRequest.tokenIds[j]);
         }
         // slither-disable-next-line costly-loop
-        _totalSupply = _totalSupply + mintRequest.tokenIds.length;
+        _totalSupply += mintRequest.tokenIds.length;
     }
 
     /**


### PR DESCRIPTION
Leverage Solidity's built-in overflow/underflow checks (Solidity 0.8.0) to avoid any potential overflows and revert the transaction if one occurs.

If an overflow occurs, `_totalSupply` would wrap around to a small value, leading to incorrect accounting of the total supply of tokens.

The best way to prevent this is to use Solidity's built-in overflow/underflow checks by using the `+=` operator instead of `=`, Solidity will automatically revert the transaction if an overflow occurs.