### PR TITLE
Fix typos in `README.md`, `IWalletProxy.sol`, and `OperatorAllowlist.sol`

### DIFF
--- a/contracts/allowlist/IWalletProxy.sol
+++ b/contracts/allowlist/IWalletProxy.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache 2.0
 pragma solidity 0.8.19;
 
-// Interface to retrieve the implemention stored inside the Proxy contract
+// Interface to retrieve the implementation stored inside the Proxy contract
 /// Interface for Passport Wallet's proxy contract.
 interface IWalletProxy {
     // Returns the current implementation address used by the proxy contract

--- a/contracts/test/allowlist/OperatorAllowlist.sol
+++ b/contracts/test/allowlist/OperatorAllowlist.sol
@@ -11,7 +11,7 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 // Interfaces
 import {IOperatorAllowlist} from "../../allowlist/IOperatorAllowlist.sol";
 
-// Interface to retrieve the implemention stored inside the Proxy contract
+// Interface to retrieve the implementation stored inside the Proxy contract
 interface IProxy {
     // Returns the current implementation address used by the proxy contract
     // solhint-disable-next-line func-name-mixedcase

--- a/contracts/trading/seaport/zones/immutable-signed-zone/v2/README.md
+++ b/contracts/trading/seaport/zones/immutable-signed-zone/v2/README.md
@@ -57,7 +57,7 @@ The contract was developed based on ImmutableSignedZone, with the addition of:
 
 ### ZoneAccessControl
 
-The contract now uses a finer grained access control with role based access with the `ZoneAccessControl` interface, rather than the `Ownable` interface in the v1 contract. A seperate `zoneManager` roles is used to manage signers and an admin role used to control roles.
+The contract now uses a finer grained access control with role based access with the `ZoneAccessControl` interface, rather than the `Ownable` interface in the v1 contract. A separate `zoneManager` roles is used to manage signers and an admin role used to control roles.
 
 ### Support of SIP7 substandard 6
 

--- a/contracts/trading/seaport/zones/immutable-signed-zone/v2/README.md
+++ b/contracts/trading/seaport/zones/immutable-signed-zone/v2/README.md
@@ -44,7 +44,7 @@ flowchart LR
 The sequence of events is as follows:
 
 1. The client makes a HTTP `POST .../fulfillment-data` request to the Immutable Orderbook, which will construct and sign an `extraData` payload to return to the client
-2. The client calls `fulfillAdvancedOrder` or `fulfillAvailableAdavancedOrders` on `ImmutableSeaport.sol` to fulfill an order
+2. The client calls `fulfillAdvancedOrder` or `fulfillAvailableAdvancedOrders` on `ImmutableSeaport.sol` to fulfill an order
 3. `ImmutableSeaport.sol` executes the fufilment by transferring items between parties
 4. `ImmutableSeaport.sol` calls `validateOrder` on `ImmutableSignedZoneV2.sol`, passing it the fulfilment execution details as well as the `extraData` parameter
 5. `ImmutableSignedZoneV2.sol` validates the fulfilment execution details using the `extraData` payload, reverting if expectations are not met

--- a/test/trading/seaport/zones/immutable-signed-zone/v1/README.md
+++ b/test/trading/seaport/zones/immutable-signed-zone/v1/README.md
@@ -4,7 +4,7 @@ ImmutableSignedZone is a implementation of the SIP-7 specification with substand
 
 ## E2E tests with signing server
 
-E2E tests will be handled in the server repository seperate to the contract.
+E2E tests will be handled in the server repository separate to the contract.
 
 ## Validate order unit tests
 


### PR DESCRIPTION
1. **`IWalletProxy.sol` & `OperatorAllowlist.sol`**:
   - Fixed `implemention` → `implementation` in comments describing proxy contract behavior.

2. **`README.md` (Seaport-related directories)**:
   - Fixed `fulfillAvailableAdavancedOrders` → `fulfillAvailableAdvancedOrders`.
   - Corrected `seperate` → `separate` in descriptions of zone management and testing.
   - Fixed `fufilment` → `fulfillment` in multiple instances.
