### PR TITLE
Update Solidity version to from 0.8.19 to 0.8.28

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -40,7 +40,7 @@
     "avoid-throw": "error",
     "avoid-tx-origin": "error",
     "check-send-result": "error",
-    "compiler-version": ["error", "0.8.19"],
+    "compiler-version": ["error", ">=0.8.19 <0.8.29"],
     "func-visibility": ["error", {"ignoreConstructors": true}],
     "multiple-sends": "warn",
     "no-complex-fallback": "warn",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ yarn add @imtbl/contracts
 Once the `contracts` package is installed, use the contracts from the library by importing them:
 
 ```solidity
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "@imtbl/contracts/contracts/token/erc721/preset/ImmutableERC721.sol";
 

--- a/contracts/access/MintingAccessControl.sol
+++ b/contracts/access/MintingAccessControl.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {AccessControlEnumerable} from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 

--- a/contracts/allowlist/IOperatorAllowlist.sol
+++ b/contracts/allowlist/IOperatorAllowlist.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 /**
  * @notice Required interface of an OperatorAllowlist compliant contract

--- a/contracts/allowlist/IWalletProxy.sol
+++ b/contracts/allowlist/IWalletProxy.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 // Interface to retrieve the implemention stored inside the Proxy contract
 /// Interface for Passport Wallet's proxy contract.

--- a/contracts/allowlist/OperatorAllowlistEnforced.sol
+++ b/contracts/allowlist/OperatorAllowlistEnforced.sol
@@ -1,7 +1,7 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
 // slither-disable-start calls-loop
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 // Allowlist Registry
 import {IOperatorAllowlist} from "./IOperatorAllowlist.sol";

--- a/contracts/allowlist/OperatorAllowlistUpgradeable.sol
+++ b/contracts/allowlist/OperatorAllowlistUpgradeable.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {UUPSUpgradeable} from "openzeppelin-contracts-upgradeable-4.9.3/proxy/utils/UUPSUpgradeable.sol";
 import {AccessControlEnumerableUpgradeable} from "openzeppelin-contracts-upgradeable-4.9.3/access/AccessControlEnumerableUpgradeable.sol";

--- a/contracts/bridge/x/v4/CoreV4.sol
+++ b/contracts/bridge/x/v4/CoreV4.sol
@@ -7,7 +7,7 @@
 //
 // This file was generated using the abi-to-sol tool.
 // the StarkEx contract ABI that was provided by StarkWare via slack.
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 // solhint-disable func-name-mixedcase
 interface CoreV4 {

--- a/contracts/bridge/x/v4/RegistrationV4.sol
+++ b/contracts/bridge/x/v4/RegistrationV4.sol
@@ -1,6 +1,6 @@
 // Copyright (c) Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {CoreV4} from "./CoreV4.sol";
 

--- a/contracts/deployer/AccessControlledDeployer.sol
+++ b/contracts/deployer/AccessControlledDeployer.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {IDeployer} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IDeployer.sol";
 import {Pausable} from "@openzeppelin/contracts/security/Pausable.sol";

--- a/contracts/deployer/create/OwnableCreateDeploy.sol
+++ b/contracts/deployer/create/OwnableCreateDeploy.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 /**
  * @title OwnableCreateDeploy Contract

--- a/contracts/deployer/create2/OwnableCreate2Deployer.sol
+++ b/contracts/deployer/create2/OwnableCreate2Deployer.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Deployer} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/deploy/Deployer.sol";

--- a/contracts/deployer/create3/OwnableCreate3.sol
+++ b/contracts/deployer/create3/OwnableCreate3.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {IDeploy} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IDeploy.sol";
 import {ContractAddress} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/libs/ContractAddress.sol";

--- a/contracts/deployer/create3/OwnableCreate3Address.sol
+++ b/contracts/deployer/create3/OwnableCreate3Address.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {OwnableCreateDeploy} from "../create/OwnableCreateDeploy.sol";
 

--- a/contracts/deployer/create3/OwnableCreate3Deployer.sol
+++ b/contracts/deployer/create3/OwnableCreate3Deployer.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Deployer} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/deploy/Deployer.sol";

--- a/contracts/errors/Errors.sol
+++ b/contracts/errors/Errors.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 interface IImmutableERC721Errors {
     /// @dev Caller tried to mint an already burned token

--- a/contracts/errors/PaymentSplitterErrors.sol
+++ b/contracts/errors/PaymentSplitterErrors.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 //SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 interface IPaymentSplitterErrors {
     /// @dev caller tried to add payees with shares of unequal length

--- a/contracts/games/gems/GemGame.sol
+++ b/contracts/games/gems/GemGame.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache 2
 // solhint-disable not-rely-on-time
 
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {Pausable} from "@openzeppelin/contracts/security/Pausable.sol";

--- a/contracts/mocks/MockDisguisedEOA.sol
+++ b/contracts/mocks/MockDisguisedEOA.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 

--- a/contracts/mocks/MockEIP1271Wallet.sol
+++ b/contracts/mocks/MockEIP1271Wallet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";

--- a/contracts/mocks/MockFactory.sol
+++ b/contracts/mocks/MockFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/mocks/MockFunctions.sol
+++ b/contracts/mocks/MockFunctions.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Unlicense
 // This file is part of the test code for GuardedMulticaller
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 contract MockFunctions {
     error RevertWithData(uint256 value);

--- a/contracts/mocks/MockMarketplace.sol
+++ b/contracts/mocks/MockMarketplace.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC2981} from "@openzeppelin/contracts/interfaces/IERC2981.sol";

--- a/contracts/mocks/MockOnReceive.sol
+++ b/contracts/mocks/MockOnReceive.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 

--- a/contracts/mocks/MockWallet.sol
+++ b/contracts/mocks/MockWallet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";

--- a/contracts/mocks/MockWalletFactory.sol
+++ b/contracts/mocks/MockWalletFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 contract MockWalletFactory {
     bytes private constant WALLET_CREATION_CODE =

--- a/contracts/multicall/GuardedMulticaller.sol
+++ b/contracts/multicall/GuardedMulticaller.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 // Signature Validation
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";

--- a/contracts/multicall/GuardedMulticaller2.sol
+++ b/contracts/multicall/GuardedMulticaller2.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 // Signature Validation
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";

--- a/contracts/payment-splitter/PaymentSplitter.sol
+++ b/contracts/payment-splitter/PaymentSplitter.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/contracts/staking/StakeHolder.sol
+++ b/contracts/staking/StakeHolder.sol
@@ -1,6 +1,6 @@
 // Copyright (c) Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {UUPSUpgradeable} from "openzeppelin-contracts-upgradeable-4.9.3/proxy/utils/UUPSUpgradeable.sol";
 import {AccessControlEnumerableUpgradeable} from "openzeppelin-contracts-upgradeable-4.9.3/access/AccessControlEnumerableUpgradeable.sol";

--- a/contracts/test/allowlist/OperatorAllowlist.sol
+++ b/contracts/test/allowlist/OperatorAllowlist.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 // Access Control
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";

--- a/contracts/token/erc1155/abstract/ERC1155Permit.sol
+++ b/contracts/token/erc1155/abstract/ERC1155Permit.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {ERC1155Burnable, ERC1155} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Burnable.sol";
 import {EIP712, ECDSA} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";

--- a/contracts/token/erc1155/abstract/IERC1155Permit.sol
+++ b/contracts/token/erc1155/abstract/IERC1155Permit.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (token/ERC20/extensions/IERC20Permit.sol)
 
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 interface IERC1155Permit {
     function permit(address owner, address spender, bool approved, uint256 deadline, bytes memory sig) external;

--- a/contracts/token/erc1155/abstract/ImmutableERC1155Base.sol
+++ b/contracts/token/erc1155/abstract/ImmutableERC1155Base.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {ERC1155Permit, ERC1155} from "../../../token/erc1155/abstract/ERC1155Permit.sol";
 

--- a/contracts/token/erc1155/preset/ImmutableERC1155.sol
+++ b/contracts/token/erc1155/preset/ImmutableERC1155.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {ImmutableERC1155Base} from "../abstract/ImmutableERC1155Base.sol";
 

--- a/contracts/token/erc20/preset/Errors.sol
+++ b/contracts/token/erc20/preset/Errors.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 interface IImmutableERC20Errors {
     error RenounceOwnershipNotAllowed();

--- a/contracts/token/erc20/preset/ImmutableERC20FixedSupplyNoBurn.sol
+++ b/contracts/token/erc20/preset/ImmutableERC20FixedSupplyNoBurn.sol
@@ -1,6 +1,6 @@
 // Copyright (c) Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/token/erc20/preset/ImmutableERC20MinterBurnerPermit.sol
+++ b/contracts/token/erc20/preset/ImmutableERC20MinterBurnerPermit.sol
@@ -1,6 +1,6 @@
 // Copyright (c) Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {ERC20Permit, ERC20} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/contracts/token/erc721/abstract/ERC721Hybrid.sol
+++ b/contracts/token/erc721/abstract/ERC721Hybrid.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {BitMaps} from "@openzeppelin/contracts/utils/structs/BitMaps.sol";

--- a/contracts/token/erc721/abstract/ERC721HybridPermit.sol
+++ b/contracts/token/erc721/abstract/ERC721HybridPermit.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";

--- a/contracts/token/erc721/abstract/ERC721Permit.sol
+++ b/contracts/token/erc721/abstract/ERC721Permit.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";

--- a/contracts/token/erc721/abstract/IERC4494.sol
+++ b/contracts/token/erc721/abstract/IERC4494.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 

--- a/contracts/token/erc721/abstract/ImmutableERC721Base.sol
+++ b/contracts/token/erc721/abstract/ImmutableERC721Base.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 // Token
 import {ERC721Permit, ERC721, ERC721Burnable} from "./ERC721Permit.sol";

--- a/contracts/token/erc721/abstract/ImmutableERC721HybridBase.sol
+++ b/contracts/token/erc721/abstract/ImmutableERC721HybridBase.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {AccessControlEnumerable, MintingAccessControl} from "../../../access/MintingAccessControl.sol";
 import {ERC2981} from "@openzeppelin/contracts/token/common/ERC2981.sol";

--- a/contracts/token/erc721/erc721psi/ERC721Psi.sol
+++ b/contracts/token/erc721/erc721psi/ERC721Psi.sol
@@ -11,7 +11,7 @@
  *  - npm: https://www.npmjs.com/package/erc721psi
  */
 // solhint-disable
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";

--- a/contracts/token/erc721/erc721psi/ERC721PsiBurnable.sol
+++ b/contracts/token/erc721/erc721psi/ERC721PsiBurnable.sol
@@ -7,7 +7,7 @@
  *  | |____| | \ \| |____  / /   / /_ | |  | |
  *  |______|_|  \_\\_____|/_/   |____||_|  |_|
  */
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {BitMaps} from "solidity-bits/contracts/BitMaps.sol";
 import {ERC721Psi} from "./ERC721Psi.sol";

--- a/contracts/token/erc721/preset/ImmutableERC721.sol
+++ b/contracts/token/erc721/preset/ImmutableERC721.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {ImmutableERC721HybridBase} from "../abstract/ImmutableERC721HybridBase.sol";
 

--- a/contracts/token/erc721/preset/ImmutableERC721MintByID.sol
+++ b/contracts/token/erc721/preset/ImmutableERC721MintByID.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {ImmutableERC721Base} from "../abstract/ImmutableERC721Base.sol";
 

--- a/test/allowlist/AllowlistImmutableERC721MintByIDTransferApprovals.t.sol
+++ b/test/allowlist/AllowlistImmutableERC721MintByIDTransferApprovals.t.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 

--- a/test/allowlist/AllowlistImmutableERC721TransferApprovals.t.sol
+++ b/test/allowlist/AllowlistImmutableERC721TransferApprovals.t.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 

--- a/test/allowlist/MockOAL.sol
+++ b/test/allowlist/MockOAL.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {OperatorAllowlistUpgradeable} from "../../contracts/allowlist/OperatorAllowlistUpgradeable.sol";
 

--- a/test/allowlist/OperatorAllowlistUpgradeable.t.sol
+++ b/test/allowlist/OperatorAllowlistUpgradeable.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/test/bridge/x/v4/MockCoreV4.sol
+++ b/test/bridge/x/v4/MockCoreV4.sol
@@ -1,6 +1,6 @@
 // Copyright (c) Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {CoreV4} from "../../../../contracts/bridge/x/v4/CoreV4.sol";
 import {Asset} from "../../../../contracts/token/erc721/x/Asset.sol";

--- a/test/deployer/AccessControlledDeployer.t.sol
+++ b/test/deployer/AccessControlledDeployer.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";

--- a/test/deployer/create2/Create2Utils.sol
+++ b/test/deployer/create2/Create2Utils.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 

--- a/test/deployer/create2/OwnableCreate2Deployer.t.sol
+++ b/test/deployer/create2/OwnableCreate2Deployer.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 import {IDeploy} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IDeploy.sol";

--- a/test/deployer/create3/Create3Utils.sol
+++ b/test/deployer/create3/Create3Utils.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 import {IDeployer} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IDeployer.sol";

--- a/test/deployer/create3/OwnableCreate3Deployer.t.sol
+++ b/test/deployer/create3/OwnableCreate3Deployer.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2023
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 import {IDeploy} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IDeploy.sol";

--- a/test/games/gems/GemGame.t.sol
+++ b/test/games/gems/GemGame.t.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache 2.0
 // solhint-disable not-rely-on-time
 
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 import {GemGame, Unauthorized, ContractPaused} from "../../../contracts/games/gems/GemGame.sol";

--- a/test/multicall/GuardedMulticaller2.t.sol
+++ b/test/multicall/GuardedMulticaller2.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 import {GuardedMulticaller2} from "../../contracts/multicall/GuardedMulticaller2.sol";

--- a/test/multicall/SigUtils.t.sol
+++ b/test/multicall/SigUtils.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {GuardedMulticaller2} from "../../contracts/multicall/GuardedMulticaller2.sol";
 

--- a/test/payment-splitter/PaymentSplitter.t.sol
+++ b/test/payment-splitter/PaymentSplitter.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 import {PaymentSplitter} from "../../contracts/payment-splitter/PaymentSplitter.sol";

--- a/test/staking/StakeHolderAttackWallet.sol
+++ b/test/staking/StakeHolderAttackWallet.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {StakeHolder} from "../../contracts/staking/StakeHolder.sol";
 

--- a/test/staking/StakeHolderBase.t.sol
+++ b/test/staking/StakeHolderBase.t.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache 2.0
 // solhint-disable not-rely-on-time
 
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 // solhint-disable-next-line no-global-import
 import "forge-std/Test.sol";

--- a/test/staking/StakeHolderConfig.t.sol
+++ b/test/staking/StakeHolderConfig.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 // solhint-disable-next-line no-global-import
 import "forge-std/Test.sol";

--- a/test/staking/StakeHolderInit.t.sol
+++ b/test/staking/StakeHolderInit.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 // solhint-disable-next-line no-global-import
 import "forge-std/Test.sol";

--- a/test/staking/StakeHolderOperational.t.sol
+++ b/test/staking/StakeHolderOperational.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 // solhint-disable-next-line no-global-import
 import "forge-std/Test.sol";

--- a/test/token/erc1155/ImmutableERC1155.t.sol
+++ b/test/token/erc1155/ImmutableERC1155.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 import {ImmutableERC1155} from "../../../contracts/token/erc1155/preset/ImmutableERC1155.sol";

--- a/test/token/erc1155/ImmutableERC1155Costs.t.sol
+++ b/test/token/erc1155/ImmutableERC1155Costs.t.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2024
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 import {ImmutableERC1155} from "../../../contracts/token/erc1155/preset/ImmutableERC1155.sol";

--- a/test/token/erc20/preset/ImmutableERC20FixedSupplyNoBurn.t.sol
+++ b/test/token/erc20/preset/ImmutableERC20FixedSupplyNoBurn.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 

--- a/test/token/erc20/preset/ImmutableERC20MinterBurnerPermit.t.sol
+++ b/test/token/erc20/preset/ImmutableERC20MinterBurnerPermit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 

--- a/test/utils/DeployAllowlistProxy.sol
+++ b/test/utils/DeployAllowlistProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {OperatorAllowlistUpgradeable} from "../../contracts/allowlist/OperatorAllowlistUpgradeable.sol";

--- a/test/utils/DeployMockMarketPlace.sol
+++ b/test/utils/DeployMockMarketPlace.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity ^0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import {MockMarketplace} from "../../contracts/mocks/MockMarketplace.sol";
 

--- a/test/utils/DeploySCW.sol
+++ b/test/utils/DeploySCW.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2.0
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 import {MockWallet} from "../../contracts/mocks/MockWallet.sol";

--- a/test/utils/Sign.sol
+++ b/test/utils/Sign.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity >=0.8.19 <0.8.29;
 
 import "forge-std/Test.sol";
 


### PR DESCRIPTION
Change Solidity version of all contracts from 0.8.19 to between 0.8.19 to 0.8.28

Doing this change will make it easier for partners to integrate our code into their projects.

Immutable zkEVM supports Solidity version 0.8.28