### PR TITLE
Staking: Addressing internal audit feedback

### DIFF
--- a/contracts/staking/README.md
+++ b/contracts/staking/README.md
@@ -40,7 +40,7 @@ To stake, any account should call `stake()`, passing in the amount to be staked 
 
 To unstake, the account that previously staked should call, `unstake(uint256 _amountToUnstake)`.
 
-Accounts that wish to distribute rewards should call, `distributeRewards(AccountAmount[] calldata _recipientsAndAmounts)`. The `AccountAmount` structure consists of recipient address and amount to distribute pairs. Distributions can only be made to accounts that have previously or are currently staking. The amount to be distributed must be passed in as msg.value and must equal to the sum of the amounts specified in the `_recipientsAndAmounts` array.
+Accounts that have DISTRIBUTE_ROLE that wish to distribute rewards should call, `distributeRewards(AccountAmount[] calldata _recipientsAndAmounts)`. The `AccountAmount` structure consists of recipient address and amount to distribute pairs. Distributions can only be made to accounts that have previously or are currently staking. The amount to be distributed must be passed in as msg.value and must equal to the sum of the amounts specified in the `_recipientsAndAmounts` array.
 
 The `stakers` array needs to be analysed to determine which accounts have staked and how much. The following functions provide access to this data structure:
 

--- a/script/staking/DeployStakeHolder.sol
+++ b/script/staking/DeployStakeHolder.sol
@@ -34,6 +34,7 @@ struct DeploymentArgs {
 struct StakeHolderContractArgs {
     address roleAdmin;
     address upgradeAdmin;
+    address distributeAdmin;
 }
 
 /**
@@ -58,7 +59,8 @@ contract DeployStakeHolder is Test {
 
         StakeHolderContractArgs memory stakeHolderContractArgs = StakeHolderContractArgs({
             roleAdmin: makeAddr("role"),
-            upgradeAdmin: makeAddr("upgrade")
+            upgradeAdmin: makeAddr("upgrade"),
+            distributeAdmin: makeAddr("distribute")
         });
 
         // Run deployment against forked testnet
@@ -75,13 +77,14 @@ contract DeployStakeHolder is Test {
         address factory = vm.envAddress("OWNABLE_CREATE3_FACTORY_ADDRESS");
         address roleAdmin = vm.envAddress("ROLE_ADMIN");
         address upgradeAdmin = vm.envAddress("UPGRADE_ADMIN");
+        address distributeAdmin = vm.envAddress("DISTRIBUTE_ADMIN");
         string memory salt1 = vm.envString("IMPL_SALT");
         string memory salt2 = vm.envString("PROXY_SALT");
 
         DeploymentArgs memory deploymentArgs = DeploymentArgs({signer: signer, factory: factory, salt1: salt1, salt2: salt2});
 
         StakeHolderContractArgs memory stakeHolderContractArgs =
-            StakeHolderContractArgs({roleAdmin: roleAdmin, upgradeAdmin: upgradeAdmin});
+            StakeHolderContractArgs({roleAdmin: roleAdmin, upgradeAdmin: upgradeAdmin, distributeAdmin: distributeAdmin});
 
         _deploy(deploymentArgs, stakeHolderContractArgs);
     }
@@ -107,7 +110,8 @@ contract DeployStakeHolder is Test {
 
         // Create init data for teh ERC1967 Proxy
         bytes memory initData = abi.encodeWithSelector(
-            StakeHolder.initialize.selector, stakeHolderContractArgs.roleAdmin, stakeHolderContractArgs.upgradeAdmin
+            StakeHolder.initialize.selector, stakeHolderContractArgs.roleAdmin, 
+            stakeHolderContractArgs.upgradeAdmin, stakeHolderContractArgs.distributeAdmin
         );
 
         // Deploy ERC1967Proxy via the Ownable Create3 factory.

--- a/test/staking/README.md
+++ b/test/staking/README.md
@@ -48,4 +48,5 @@ Operational tests (in [StakeHolderOperational.t.sol](../../contracts/staking/Sta
 | testDistributeMismatch         | Fail if the total to distribute does not equal msg.value.   | No         | Yes         |
 | testDistributeToEmptyAccount   | Stake, unstake, distribute rewards.                         | Yes        | Yes         |
 | testDistributeToUnusedAccount  | Attempt to distribute rewards to an account that has never staked. | No  | Yes         |
+| testDistributeBadAuth  | Attempt to distribute rewards using an unauthorised account.        | No  | Yes         |
 

--- a/test/staking/StakeHolderBase.t.sol
+++ b/test/staking/StakeHolderBase.t.sol
@@ -15,12 +15,14 @@ contract StakeHolderBaseTest is Test {
 
     bytes32 public defaultAdminRole;
     bytes32 public upgradeRole;
+    bytes32 public distributeRole;
 
     ERC1967Proxy public proxy;
     StakeHolder public stakeHolder;
 
     address public roleAdmin;
     address public upgradeAdmin;
+    address public distributeAdmin;
 
     address public staker1;
     address public staker2;
@@ -30,6 +32,7 @@ contract StakeHolderBaseTest is Test {
     function setUp() public {
         roleAdmin = makeAddr("RoleAdmin");
         upgradeAdmin = makeAddr("UpgradeAdmin");
+        distributeAdmin = makeAddr("DistributeAdmin");
 
         staker1 = makeAddr("Staker1");
         staker2 = makeAddr("Staker2");
@@ -39,7 +42,7 @@ contract StakeHolderBaseTest is Test {
         StakeHolder impl = new StakeHolder();
 
         bytes memory initData = abi.encodeWithSelector(
-            StakeHolder.initialize.selector, roleAdmin, upgradeAdmin
+            StakeHolder.initialize.selector, roleAdmin, upgradeAdmin, distributeAdmin
         );
 
         proxy = new ERC1967Proxy(address(impl), initData);
@@ -47,5 +50,6 @@ contract StakeHolderBaseTest is Test {
 
         defaultAdminRole = stakeHolder.DEFAULT_ADMIN_ROLE();
         upgradeRole = stakeHolder.UPGRADE_ROLE();
+        distributeRole = stakeHolder.DISTRIBUTE_ROLE();
     }
 }

--- a/test/staking/StakeHolderInit.t.sol
+++ b/test/staking/StakeHolderInit.t.sol
@@ -20,7 +20,9 @@ contract StakeHolderInitTest is StakeHolderBaseTest {
     function testAdmins() public {
         assertEq(stakeHolder.getRoleMemberCount(defaultAdminRole), 1, "Expect one role admin");
         assertEq(stakeHolder.getRoleMemberCount(upgradeRole), 1, "Expect one upgrade admin");
+        assertEq(stakeHolder.getRoleMemberCount(distributeRole), 1, "Expect one distribute admin");
         assertTrue(stakeHolder.hasRole(defaultAdminRole, roleAdmin), "Expect roleAdmin is role admin");
         assertTrue(stakeHolder.hasRole(upgradeRole, upgradeAdmin), "Expect upgradeAdmin is upgrade admin");
+        assertTrue(stakeHolder.hasRole(distributeRole, distributeAdmin), "Expect distributeAdmin is distribute admin");
     }
 }


### PR DESCRIPTION
This PR addresses internal audit feedback for the staking contract. The changes are:

* Add a DISTRIBUTE_ROLE to the staking contract.
* Require the caller of distribute() to have the DISTRIBUTE_ROLE