### PR TITLE
Fix Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,6 @@ Immutable zkEVM Contracts are released under the Apache-2.0 license. See [LICENS
 ### Socials
 
 - [Twitter](https://twitter.com/Immutable)
-- [Discord](https://discord.gg/6GjgPkp464)
+- [Discord](https://discord.gg/immutable-play)
 - [Telegram](https://t.me/immutablex)
 - [Reddit](https://www.reddit.com/r/ImmutableX/)

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,5 +1,5 @@
 {
-  "detectors_to_exclude": "naming-convention, solc-version, similar-names, timestamp, assembly",
+  "detectors_to_exclude": "naming-convention, solc-version, similar-names, timestamp, assembly, unindexed-event-address",
 
   "filter_paths": "lib"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change plus a Slither config tweak to suppress the `unindexed-event-address` detector; no runtime/contract logic is modified.
> 
> **Overview**
> Updates the `README.md` Discord invite link under *Socials*.
> 
> Adjusts `slither.config.json` to also exclude the `unindexed-event-address` detector during static analysis.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43c419c1b0e08810ebb94b088ab30b219d8035e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->