### PR TITLE
Use supported node and npm version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # pin@v6.3.0
         with:
           node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false  # never use caching in release builds
 
       - name: Install dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,8 +26,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # pin@v6.3.0
         with:
-          node-version: '22' # matches .nvmrc
-          registry-url: https://registry.npmjs.org
+          node-version: '24'
           package-manager-cache: false  # never use caching in release builds
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/immutable/contracts.git"
+    "url": "git+https://github.com/immutable/contracts.git"
   },
   "homepage": "https://github.com/immutable/contracts",
   "bugs": {


### PR DESCRIPTION
Matching the version details from setup-node docs
https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publishing-to-npm-with-trusted-publisher-oidc

Left registry-url in place and also run npm pkg fix as requested in pipeline output