### PR TITLE
PLT-1330: align CODEOWNERS with new GitHub teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global owner
-* @immutable/rollups
+* @immutable/ped-engineering-blockchain-list
 
 # Github actions
-/.github/ @immutable/rollups  @immutable/security
+/.github/ @immutable/ped-engineering-blockchain-list  @immutable/security


### PR DESCRIPTION
Aligns CODEOWNERS with the new GitHub team structure (PLT-1330).

Mapping applied (only the entries present in this repo are changed):
- `rollups`, `blockchain-services` → `ped-engineering-blockchain-list`
